### PR TITLE
Add support for HTTPS/SSL enabled APICs

### DIFF
--- a/acisession.py
+++ b/acisession.py
@@ -3,6 +3,7 @@
 """
 import logging
 import json
+
 import requests
 
 
@@ -11,13 +12,15 @@ class Session(object):
        This class contains the connectivity information for talking to the
        APIC.
     """
-    def __init__(self, ipaddr, uid, pwd):
+
+    def __init__(self, ipaddr, uid, pwd, verify_certificates=False):
         self.ipaddr = ipaddr
         self.uid = uid
         self.pwd = pwd
         # self.api = 'http://%s:80/api/' % self.ip # 7580
         self.api = ipaddr
         self.session = None
+        self.verify_certificates = verify_certificates
 
     def login(self):
         """Login to the APIC"""
@@ -27,14 +30,14 @@ class Session(object):
                                                'pwd': self.pwd}}}
         jcred = json.dumps(name_pwd)
         self.session = requests.Session()
-        ret = self.session.post(login_url, data=jcred)
+        ret = self.session.post(login_url, data=jcred, verify=self.verify_certificates)
         return ret
 
     def push_to_apic(self, url, data):
         """Push the object to the APIC"""
         post_url = self.api + url
         logging.debug('Posting url: %s data: %s', post_url, data)
-        resp = self.session.post(post_url, data=json.dumps(data))
+        resp = self.session.post(post_url, data=json.dumps(data), verify=self.verify_certificates)
         logging.debug('Response: %s %s', resp, resp.text)
         return resp
 
@@ -42,7 +45,7 @@ class Session(object):
         """Perform a REST GET call to the APIC."""
         get_url = self.api + url
         logging.debug(get_url)
-        resp = self.session.get(get_url)
+        resp = self.session.get(get_url, verify=self.verify_certificates)
         logging.debug(resp)
         logging.debug(resp.text)
         return resp


### PR DESCRIPTION
Many APICs are now running exclusively in HTTPS mode. By default the
certificate on the APIC is self-signed and therefore requests will fail.

By default the script will now not verify certificates. Added the flag
`-c / --verify-certificates` to re-enable cert verification.
