### PR TITLE
Add diagram generation tool to acitoolkit applications

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1274,21 +1274,24 @@ class Contract(BaseContract):
         contract_data = working_data[0]['vzBrCP']
         contract = Contract(str(contract_data['attributes']['name']),
                             parent)
-        if 'children' in contract_data:
-            for child in contract_data['children']:
-                if 'vzSubj' in child:
-                    subject = child['vzSubj']
-                    for subj_child in subject['children']:
-                        if 'vzRsSubjFiltAtt' in subj_child:
-                            filter_attributes = subj_child['vzRsSubjFiltAtt']['attributes']
-                            filter_name = filter_attributes['rn'].split('rssubjFiltAtt-')[1]
-                            for filter in full_data[0]['fvTenant']['children']:
-                                if 'vzFilter' in filter:
-                                    match_name = filter['vzFilter']['attributes']['name']
-                                    if match_name == filter_name:
-                                        for entry in filter['vzFilter']['children']:
-                                            if 'vzEntry' in entry:
-                                                entry_obj = FilterEntry.create_from_apic_json(entry, contract)
+                            
+        if 'children' not in contract_data:
+            return
+            
+        for child in contract_data['children']:
+            if 'vzSubj' in child:
+                subject = child['vzSubj']
+                for subj_child in subject['children']:
+                    if 'vzRsSubjFiltAtt' in subj_child:
+                        filter_attributes = subj_child['vzRsSubjFiltAtt']['attributes']
+                        filter_name = filter_attributes['rn'].split('rssubjFiltAtt-')[1]
+                        for filter in full_data[0]['fvTenant']['children']:
+                            if 'vzFilter' in filter:
+                                match_name = filter['vzFilter']['attributes']['name']
+                                if match_name == filter_name:
+                                    for entry in filter['vzFilter']['children']:
+                                        if 'vzEntry' in entry:
+                                            entry_obj = FilterEntry.create_from_apic_json(entry, contract)
 
     @classmethod
     def _get_toolkit_to_apic_classmap(cls):

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1274,20 +1274,21 @@ class Contract(BaseContract):
         contract_data = working_data[0]['vzBrCP']
         contract = Contract(str(contract_data['attributes']['name']),
                             parent)
-        for child in contract_data['children']:
-            if 'vzSubj' in child:
-                subject = child['vzSubj']
-                for subj_child in subject['children']:
-                    if 'vzRsSubjFiltAtt' in subj_child:
-                        filter_attributes = subj_child['vzRsSubjFiltAtt']['attributes']
-                        filter_name = filter_attributes['rn'].split('rssubjFiltAtt-')[1]
-                        for filter in full_data[0]['fvTenant']['children']:
-                            if 'vzFilter' in filter:
-                                match_name = filter['vzFilter']['attributes']['name']
-                                if match_name == filter_name:
-                                    for entry in filter['vzFilter']['children']:
-                                        if 'vzEntry' in entry:
-                                            entry_obj = FilterEntry.create_from_apic_json(entry, contract)
+        if 'children' in contract_data:
+            for child in contract_data['children']:
+                if 'vzSubj' in child:
+                    subject = child['vzSubj']
+                    for subj_child in subject['children']:
+                        if 'vzRsSubjFiltAtt' in subj_child:
+                            filter_attributes = subj_child['vzRsSubjFiltAtt']['attributes']
+                            filter_name = filter_attributes['rn'].split('rssubjFiltAtt-')[1]
+                            for filter in full_data[0]['fvTenant']['children']:
+                                if 'vzFilter' in filter:
+                                    match_name = filter['vzFilter']['attributes']['name']
+                                    if match_name == filter_name:
+                                        for entry in filter['vzFilter']['children']:
+                                            if 'vzEntry' in entry:
+                                                entry_obj = FilterEntry.create_from_apic_json(entry, contract)
 
     @classmethod
     def _get_toolkit_to_apic_classmap(cls):

--- a/applications/diagram/README.md
+++ b/applications/diagram/README.md
@@ -1,0 +1,37 @@
+# ACI Diagram generator
+
+This is a simple application to connect to an APIC using the acitoolkit library, retrieve the configuration and generate diagrams of the configuration. 
+
+##Installation
+The main requirement is for GraphViz and the python wrapper PyGraphViz.
+
+On MacOS, the easiest way to install these is (assuming you have HomeBrew and pip setup):
+
+```bash
+brew install graphviz
+pip install pygraphviz
+```
+
+##Usage
+
+```
+usage: diagram.py [-h] -l LOGIN -p PASSWORD -u URL -o OUTPUT
+                  [-t [TENANTS [TENANTS ...]]] [-v]
+
+Generate logical diagrams of a running Cisco ACI Application Policy
+Infrastructure Controller
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l LOGIN, --login LOGIN
+                        Login for authenticating to APIC
+  -p PASSWORD, --password PASSWORD
+                        Password for authenticating to APIC
+  -u URL, --url URL     URL for connecting to APIC
+  -o OUTPUT, --output OUTPUT
+                        Output file for diagram - e.g. out.png, out.jpeg
+  -t [TENANTS [TENANTS ...]], --tenants [TENANTS [TENANTS ...]]
+                        Tenants to include when generating diagrams
+  -v, --verbose         show verbose logging information
+```
+

--- a/applications/diagram/diagram.py
+++ b/applications/diagram/diagram.py
@@ -1,0 +1,68 @@
+from acitoolkit.acitoolkit import *
+import pygraphviz as pgv
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(description="Generate logical diagrams of a running Cisco ACI Application Policy Infrastructure Controller")
+
+parser.add_argument('-l', '--login', help='Login for authenticating to APIC', required=True)
+parser.add_argument('-p', '--password', help='Password for authenticating to APIC', required=True)
+parser.add_argument('-u', '--url', help='URL for connecting to APIC', required=True)
+parser.add_argument('-o', '--output', help='Output file for diagram - e.g. out.png, out.jpeg', required=True)
+parser.add_argument('-t', '--tenants', help='Tenants to include when generating diagrams', nargs='*')
+parser.add_argument('-v', '--verbose', help='show verbose logging information', action='store_true')
+
+args = parser.parse_args()
+
+session = Session(args.url, args.login, args.password)
+try:
+    assert(session.login().ok)
+except:
+    print "Connection to APIC failed"
+    sys.exit()
+
+graph=pgv.AGraph(directed=True, rankdir="LR")
+
+if args.tenants:
+    tenants=Tenant.get_deep(session, args.tenants)
+else:
+    tenants=Tenant.get_deep(session)
+
+def tn_node(tn):
+    return "cluster-tn-"+tn.name
+
+def ctx_node(tn,ctx):
+    return tn_node(tn)+"/ctx-"+ctx.name
+    
+def bd_node(tn, bd):
+    return tn_node(tn)+"/bd-"+bd.name
+    
+def sn_node(tn, bd, sn):
+    return bd_node(tn, bd)+"/sn-"+sn.get_addr()
+
+for tenant in tenants:
+    print "Processing tenant "+tenant.name
+    
+    tncluster = graph.add_subgraph(name=tn_node(tenant), label="Tenant: "+tenant.name, color="blue")
+    
+    for context in tenant.get_children(only_class=Context):
+        tncluster.add_node(ctx_node(tenant, context), label="Private Network\n"+context.name, shape='circle')
+        
+    for bd in tenant.get_children(only_class=BridgeDomain):
+        tncluster.add_node(bd_node(tenant, bd), label="Bridge Domain\n"+bd.name, shape='box')
+        
+        if bd.get_context():
+            tncluster.add_edge(ctx_node(tenant,bd.get_context()), bd_node(tenant,bd))
+            
+        for sn in bd.get_children(only_class=Subnet):
+            tncluster.add_node(sn_node(tenant, bd, sn), label = "Subnet\n"+sn.get_addr(), shape='box', style='filled', color='lightgray')
+            tncluster.add_edge(bd_node(tenant, bd), sn_node(tenant, bd, sn))
+
+if args.verbose:
+    print "Finished loading the structure from APIC, here is the graph source (GraphViz DOT format):"
+    print "================================================================================"
+    print graph.string()    
+    print "================================================================================"
+    
+print "\n\nDrawing graph to %s"%args.output
+graph.draw(args.output, prog='dot')


### PR DESCRIPTION
I've started on a small tool to connect to an APIC (using the acitoolkit) and generate diagrams using GraphViz. At this stage it draws the logical networks for all or a subset of tenants (i.e. Contexts, Bridge Domains and Subnets) but will be expanded with application policy as well.

I'm not sure if this makes more sense as an application within acitoolkit or as a separate project ....