### PR TITLE
Set the description if the user supplies it

### DIFF
--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -554,6 +554,8 @@ class BaseACIObject(object):
         """
         attributes = {}
         attributes['name'] = self.name
+        if self.descr:
+            attributes['descr'] = self.descr
         return attributes
 
     @classmethod


### PR DESCRIPTION
I ran into an issue where I was setting the description on an object, committing it, and it was not showing up in the UI. It looks like the 'descr' attribute was never getting set.