### PR TITLE
Make acitoolkit compatible with Python3.x

### DIFF
--- a/applications/cli/acitoolkitcli.py
+++ b/applications/cli/acitoolkitcli.py
@@ -1125,11 +1125,12 @@ class ContractConfigSubMode(SubMode):
         cmd, arg, line = self.parseline(line)
 
         # to achieve the sequence_number of the subject.
-        try:
-            self.sequence_number = int(cmd)
-            cmd, arg, line = self.parseline(arg)
-        except ValueError:
-            pass
+        if cmd:
+            try:
+                self.sequence_number = int(cmd)
+                cmd, arg, line = self.parseline(arg)
+            except ValueError:
+                pass
 
         if arg == '?':
             cmds = self.completenames(cmd)
@@ -1156,7 +1157,7 @@ class CmdLine(SubMode):
         self.epg = None
         self.set_prompt()
         self.intro = ('\nCisco ACI Toolkit Command Shell\nCopyright (c)'
-                      ' 2014, Cisco Systems, Inc.  All rights reserved.')
+                      ' 2015, Cisco Systems, Inc.  All rights reserved.')
         self.negative = False
         self.configsubmode = ConfigSubMode()
         self.configsubmode.set_apic(apic)

--- a/applications/cli/acitoolkitcli.py
+++ b/applications/cli/acitoolkitcli.py
@@ -1125,12 +1125,11 @@ class ContractConfigSubMode(SubMode):
         cmd, arg, line = self.parseline(line)
 
         # to achieve the sequence_number of the subject.
-        if cmd:
-            try:
-                self.sequence_number = int(cmd)
-                cmd, arg, line = self.parseline(arg)
-            except ValueError:
-                pass
+        try:
+            self.sequence_number = int(cmd)
+            cmd, arg, line = self.parseline(arg)
+        except (ValueError, TypeError):
+            pass
 
         if arg == '?':
             cmds = self.completenames(cmd)


### PR DESCRIPTION
Hi guys, 

This is Luis Martin (lumarti2[a.t.]cisco.com), from Cisco Advanced Services EMEAR. I've been hacking the acitoolkit to make it work on Python3.x while maintaining compatibility with 2.7. Would you be up to merge these changes to make the toolkit version-independent?

CHANGELOG: 
- Modified the source files to do explicit relative imports (since Python3.x does no longer support implicit imports of files in the same package). 

- Refactored Interface-related classes so they live in aciphysobject.py, eliminating the need to create a circular dependency between acitoolkit.py and aciphysobject.py. The way it is written now prevents Python3.x from performing the imports successfully.

- Fixed all the print statements to include parenthesis (since print is now a function, not a keyword).

Note that all the existing tests under /tests pass just fine. I haven't added any new tests, since I'm not introducing any functionality here.

Please let me know if you need me to improve any portions of the code. Thanks and best regards,

Luis.