### PR TITLE
Add port to listen on command line argument to aci-endpoint-tracker-gui

### DIFF
--- a/applications/endpointtracker/aci-endpoint-tracker-gui.py
+++ b/applications/endpointtracker/aci-endpoint-tracker-gui.py
@@ -164,6 +164,12 @@ if __name__ == '__main__':
     description = ('Simple application that logs on to the APIC '
                    'and displays all of the Endpoints.')
     creds = Credentials('mysql', description)
+    creds.add_argument('-p', '--port', help='Port number to listen on', required=False)
     args = creds.get()
+    
+    try:
+        port=int(args.port)
+    except:
+        port=5000
 
-    app.run(debug=True)
+    app.run(debug=True, port=port)


### PR DESCRIPTION
Add an optional command line argument to aci-endpoint-tracker-gui that lets you choose the port to listen on (useful when you want to run endpoint tracker GUI and snapback applications on the same host, say behind a reverse proxy)