### PR TITLE
Use object name as feed entry author and apply Pylint recommendations

### DIFF
--- a/applications/eventfeeds/eventfeeds.py
+++ b/applications/eventfeeds/eventfeeds.py
@@ -55,7 +55,7 @@ def _produce_feed(feed, events):
 
         feed.add(cls, content=json_dump,
                  content_type='text',
-                 author='APIC',
+                 author=name,
                  id=name,
                  updated=timestamp)
 


### PR DESCRIPTION
In the previous revision each Atom Feed item was simply 'APIC', this commit will instead use the name of the object that generated the event. This looks better in Atom Feed readers.

Changed the logging to use %s interpolation and renamed some variables to not shadow outer scope as recommended by Pylint.