### PR TITLE
Fix of InsecureRequestWarning warning from urllib3 module

### DIFF
--- a/acitoolkit/acisession.py
+++ b/acitoolkit/acisession.py
@@ -34,6 +34,7 @@ import logging
 import json
 import requests
 from requests import Timeout, ConnectionError
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 import threading
 import time
 from websocket import create_connection, WebSocketException
@@ -369,6 +370,8 @@ class Session(object):
         name_pwd = {'aaaUser': {'attributes': {'name': self.uid,
                                                'pwd': self.pwd}}}
         jcred = json.dumps(name_pwd)
+        if not self.verify_ssl:
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         self.session = requests.Session()
         ret = self.session.post(login_url, data=jcred, verify=self.verify_ssl, timeout=timeout)
         if not ret.ok:


### PR DESCRIPTION
Warning appears when session created and executed any commands. Warning looks like:

.../python2.7/site-packages/requests/packages/urllib3/connectionpool.py:768: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)

