### PR TITLE
python 3 compatibility

### DIFF
--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -116,8 +116,6 @@ class BaseACIObject(AciSearch):
                      instance
         :param parent: Parent object within the acitoolkit object model.
         """
-        if isinstance(name, unicode):
-            name = str(name)
         if name is None or not isinstance(name, str):
             raise TypeError
         if isinstance(parent, str):


### PR DESCRIPTION
Avoid "NameError: name 'unicode' is not defined" error.
