### PR TITLE
Standardize unicast routing attribute as BridgeDomain.unicast_route.

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1815,7 +1815,7 @@ class BridgeDomain(BaseACIObject):
         self.mac = attributes.get('mac')
         self.arp_flood = attributes.get('arpFlood')
         self.unicast_route = attributes.get('unicastRoute')
-        self.unknown_unicast = attributes.get('unkMacUcastAct')
+        self.unknown_mac_unicast = attributes.get('unkMacUcastAct')
         self.unknown_multicast = attributes.get('unkMcastAct')
         self.modified_time = attributes.get('modTs')
 
@@ -1858,7 +1858,7 @@ class BridgeDomain(BaseACIObject):
                 ', '.join(subnet_str),
                 bridge_domain.mac,
                 bridge_domain.unicast_route,
-                bridge_domain.unknown_unicast,
+                bridge_domain.unknown_mac_unicast,
                 bridge_domain.unknown_multicast,
                 bridge_domain.vnid,
                 bridge_domain.scope,

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1813,7 +1813,7 @@ class BridgeDomain(BaseACIObject):
         self.vnid = attributes.get('seg')
         self.mtu = attributes.get('mtu')
         self.mac = attributes.get('mac')
-        self.route = attributes.get('unicastRoute')
+        self.unicast_route = attributes.get('unicastRoute')
         self.unknown_unicast = attributes.get('unkMacUcastAct')
         self.unknown_multicast = attributes.get('unkMcastAct')
         self.modified_time = attributes.get('modTs')
@@ -1856,7 +1856,7 @@ class BridgeDomain(BaseACIObject):
                 bridge_domain.name,
                 ', '.join(subnet_str),
                 bridge_domain.mac,
-                bridge_domain.route,
+                bridge_domain.unicast_route,
                 bridge_domain.unknown_unicast,
                 bridge_domain.unknown_multicast,
                 bridge_domain.vnid,

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1813,6 +1813,7 @@ class BridgeDomain(BaseACIObject):
         self.vnid = attributes.get('seg')
         self.mtu = attributes.get('mtu')
         self.mac = attributes.get('mac')
+        self.arp_flood = attributes.get('arpFlood')
         self.unicast_route = attributes.get('unicastRoute')
         self.unknown_unicast = attributes.get('unkMacUcastAct')
         self.unknown_multicast = attributes.get('unkMcastAct')

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -674,6 +674,15 @@ class TestBridgeDomain(unittest.TestCase):
         tenant, bd = self.create_bd()
         bd.set_unknown_mac_unicast('flood')
         self.assertTrue(bd.get_unknown_mac_unicast(), 'flood')
+
+    def test_set_mac(self):
+        """
+        Test an invalid unknown mac unicast
+        """
+        tenant, bd = self.create_bd()
+        bd.set_mac('00:11:22:33:44:55')
+        self.assertTrue(bd.mac, '00:11:22:33:44:55')
+
         
     def test_unknown_mac_unicast_invalid(self):
         """


### PR DESCRIPTION
Closes #101 