### PR TITLE
Add the ability to bind static leaves to an EPG

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -2063,11 +2063,15 @@ class Subnet(BaseACIObject):
         """
         Set the subnet address
 
-        :param scope: The subnet scope. It can be either "public", "private" or "shared".
+        :param scope: The subnet scope. It can be either "public", "private".
+        :param scope may optionally contain ",shared" appended, to mark the
+        subnet as leakable to other VRFs withing the fabric.
         """
         if scope is None:
             raise TypeError('Scope can not be set to None')
-        self._scope = scope
+        elif scope.lower() not in ["public", "private", "public,shared", "private,shared"]:
+            raise ValueError('Scope must be one "public" or "private", and optionally include ",shared" appended.')
+        self._scope = scope.lower()
 
     def get_json(self):
         """


### PR DESCRIPTION
Hi,

This patch adds the ability to bind an static leaf to an EPG. I tried to imitate the model that the toolkit follows for the interfaces but unfortunately it wasn't possible, since one can add encapsulation information to an L2Interface but it doesn't make sense to do that for a Node object, so even if we could do epg.attach(node) where node is of type Node, we'd be missing the necessary encap information for the EPG binding.

I am up to code this in a different way, but I studied the problem for a while and this implementation was the easiest and cleanest way I could find.

Please let me know. Best regards,

Luis.

PS: Here's code that consumes the new method.

```
        epg = EPG("db-01", ap)
        epg.add_static_leaf_binding(101, "vlan", 405)
        epg.add_static_leaf_binding(102, "vlan", 406, encap_mode="native")
        epg.add_static_leaf_binding(103, "vxlan", 50)
        epg.add_static_leaf_binding(104, "nvgre", 406, pod=2)
```