### PR TITLE
Add the ability to bind static leaves to an EPG.

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -909,7 +909,8 @@ class EPG(CommonEPG):
                                         self.consume(contract)
         super(EPG, self)._extract_relationships(data)
 
-    def add_static_leaf_binding(self, leaf_id, encap_type, encap_id, encap_mode="regular", immediacy="immediate", pod=1):
+
+    def add_static_leaf_binding(self, leaf_id, encap_type, encap_id, encap_mode="regular", immediacy="lazy", pod=1):
         """
         Adds a static leaf binding to this EPG.
 
@@ -929,6 +930,8 @@ class EPG(CommonEPG):
         :param pod: Integer containing the ACI Pod where the supplied leaf is located.
         :param immediacy: String containing either "immediate" or "lazy"
         """
+        if immediacy not in ('immediate', 'lazy'):
+            raise ValueError("Immediacy must be one of 'immediate' or 'lazy'")
         if encap_type not in ('vlan', 'vxlan', 'nvgre'):
             raise ValueError("Encap type must be one of 'vlan', 'vxlan', or 'nvgre'")
         if encap_mode not in ('regular', 'untagged', 'native'):


### PR DESCRIPTION
Hi,

This patch adds the ability to bind an static leaf to an EPG. I tried to imitate the model that the toolkit follows for the interfaces but unfortunately it wasn't possible, since one can add encapsulation information to an L2Interface but it doesn't make sense to do that for a Node object, so even if we could do epg.attach(node) where node is of type Node, we'd be missing the necessary encap information for the EPG binding.

I am up to code this in a different way, but I studied the problem for a while and this implementation was the easiest and cleanest way I could find.

Please let me know. Best regards,

Luis.

PS: Here's code that consumes the new method.

```
        epg = EPG("db-01", ap)
        epg.add_static_leaf_binding(101, "vlan", 405)
        epg.add_static_leaf_binding(102, "vlan", 406, encap_mode="native")
        epg.add_static_leaf_binding(103, "vxlan", 50)
        epg.add_static_leaf_binding(104, "nvgre", 406, pod=2)
```