### PR TITLE
Improve the Toolkit's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,94 @@
 # acitoolkit [![Documentation Status](https://readthedocs.org/projects/acitoolkit/badge/?version=latest)](https://readthedocs.org/projects/acitoolkit/?badge=latest) [![Build Status](https://api.shippable.com/projects/54ea96315ab6cc13528d52ad/badge?branchName=master)](https://app.shippable.com/projects/54ea96315ab6cc13528d52ad/builds/latest) [![Code Health](https://landscape.io/github/datacenter/acitoolkit/master/landscape.svg?style=flat)](https://landscape.io/github/datacenter/acitoolkit/master)
 
+       ____ _                    _    ____ ___   _____           _ _    _ _
+      / ___(_)___  ___ ___      / \  / ___|_ _| |_   _|__   ___ | | | _(_) |_
+     | |   | / __|/ __/ _ \    / _ \| |    | |    | |/ _ \ / _ \| | |/ / | __|
+     | |___| \__ \ (_| (_) |  / ___ \ |___ | |    | | (_) | (_) | |   <| | |_
+      \____|_|___/\___\___/  /_/   \_\____|___|   |_|\___/ \___/|_|_|\_\_|\__|
+
 
 # Description
 
-The ACI Toolkit is a set of python libraries that allow basic
-configuration of the Cisco APIC controller. It is intended to allow users to quickly begin using the REST API and accelerate the learning curve necessary to begin using the APIC.
+The ACI Toolkit is a **Python library** that makes it much easier to
+**interact with a Cisco ACI fabric** than other traditional approaches
+(using the Cobra SDK or calling the REST API directly). It
+**can be used to build all sorts of tools**,
+ranging from deployment automation to operation monitoring.
 
-The full documentation is published at the following link:
-[http://datacenter.github.io/acitoolkit/](http://datacenter.github.io/acitoolkit/)
+The library provides the ability to implement most use cases in an easy manner,
+without having to deal with the complete ACI object model but instead with a
+very **small subset of classes that hide most of the underlying complexity**
+from the user.
+
+Apart from the actual library, the ACI toolkit
+**also includes a set of miscellaneous tools** such an endpoint tracker,
+a diagram generator or a tool to identify configuration that deviates from
+Cisco's best practices.
+
+
+# Documentation
+
+Full documentation for the ACI toolkit is published at the following link:
+[http://acitoolkit.readthedocs.org/en/latest/](http://acitoolkit.readthedocs.org/en/latest/)
 
 
 # Installation
 
-## Environment
+## Required Environment
 
-Required
-
-* Python 2.7+
+* Python 2.7 or Python3.x
 * [setuptools package](https://pypi.python.org/pypi/setuptools)
 
 ## Downloading
 
-Option A:
+**Option A: GIT**
 
-If you have git installed, clone the repository
+If you have git installed, you can clone the repository as follows:
 
     git clone https://github.com/datacenter/acitoolkit.git
 
-Option B:
+**Option B: Direct Download**
 
-If you don't have git, [download a zip copy of the repository](https://github.com/datacenter/acitoolkit/archive/master.zip) and extract.
+If you don't have GIT you can download the repository as a ZIP file and extract
+the contents to a local directory:
 
-Option C:
+[https://github.com/datacenter/acitoolkit/archive/master.zip](https://github.com/datacenter/acitoolkit/archive/master.zip)
 
-The latest build of this project is also available as a Docker image from Docker Hub
+**Option C: Docker**
+
+The latest build of this project is also available as a Docker image from
+Docker Hub:
 
     docker pull dockercisco/acitoolkit 
 
 ## Installing
 
-After downloading, install using setuptools.
+Once you have the source files in a local directory, it needs to be installed
+using setuptools.
 
     cd acitoolkit
     python setup.py install
 
-If you plan on modifying the actual toolkit files, you should install the developer environment that will link the package installation to your development directory.
+Note that if you need to install it on a specific version of python, you may
+need to call it explicitly. For example:
+
+    python2.7 setup.py install
+    python3 setup.py install
+
+If you plan on modifying the actual toolkit files, you should install the
+developer environment that will link the package installation to your
+development directory.
 
     cd acitoolkit
     python setup.py develop
 
+
 # Usage
 
-A tutorial and overview of the acitoolkit object model can be found in
-the Documentation section found at
-[http://datacenter.github.io/acitoolkit/](http://datacenter.github.io/acitoolkit/)
+A tutorial and an overview of the acitoolkit object model can be found at:
+
+[http://acitoolkit.readthedocs.org/en/latest/](http://acitoolkit.readthedocs.org/en/latest/)
+
 
 # License
 
@@ -70,3 +105,14 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Contributing
+
+The ACI toolkit is maintained by Cisco but it's open source software so anyone
+can contribute to it. Feel free to clone the toolkit and extend it to your
+needs.
+
+If you think your enhancements can be useful for the wider community, please
+issue a pull request. If your code meets our quality standards, we'd be happy
+to merge it on the official trunk and credit you (or your organization) in
+the contributors file.


### PR DESCRIPTION
This patch modifies the ACI toolkit's README file so it contains a bit more information and looks cleaner. Since this is often the first thing that newcomers see, I think it's beneficial to work a bit on the messaging and the look&feel. It also adds a "Contributing" section encouraging users to clone the repository and extend it to their needs.
