### PR TITLE
Minor enhancements

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1788,6 +1788,14 @@ class BridgeDomain(BaseACIObject):
         """
         return self.unicast_route == 'yes'
 
+    def get_unicast_route(self):
+        """
+        Get the Unicast Routing policy for this BD
+
+        :returns: a string containing the unicast routing policy of the BridgeDomain
+        """
+        return self.unicast_route
+
     def get_json(self):
         """
         Returns json representation of the bridge domain

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1763,6 +1763,14 @@ class BridgeDomain(BaseACIObject):
         """
         return self.arp_flood == 'yes'
 
+    def get_arp_flood(self):
+        """
+        Get the ARP flooding policy for this BD
+
+        :returns: a string containing the ARP flooding policy of the BridgeDomain
+        """
+        return self.arp_flood
+
     def set_unicast_route(self, route):
         """
         Set the unicast route for this BD

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1718,6 +1718,15 @@ class BridgeDomain(BaseACIObject):
 
         self.mac = mac
 
+    def get_mac(self):
+        """
+        Get the mac address for the BD
+
+        :returns: string containing the mac address of the BD (e.g. 00:22:BD:F8:19:FF)
+        """
+
+        return self.mac
+
     def set_unknown_multicast(self, multicast):
         """
         Set the unknown multicast for this BD


### PR DESCRIPTION
Add a few missing methods to the toolkit, for completeness and consistency. Note that some of the methods requested can be considered redundant (e.g. get_arp_flood() when is_arp_flood() already exists). The reason why they were added is because that allows an application to retrieve state of the policy and push it to a different APIC without having to figure out what kind of parameter needs to be passed to the setter (e.g otherwise one needs to figure out what value needs to be passed to "set_arp_flood() when is_arp_flood() returns True. In this case, we'd need to pass "yes" to the setter, making it slightly harder to code it).

