### PR TITLE
Minor enhancements (conflicts fixed)

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1759,6 +1759,15 @@ class BridgeDomain(BaseACIObject):
 
         self.mac = mac
 
+    def get_mac(self):
+        """
+        Get the mac address for the BD
+
+        :returns: string containing the mac address of the BD (e.g. 00:22:BD:F8:19:FF)
+        """
+
+        return self.mac
+
     def set_unknown_multicast(self, multicast):
         """
         Set the unknown multicast for this BD
@@ -1795,6 +1804,14 @@ class BridgeDomain(BaseACIObject):
         """
         return self.arp_flood == 'yes'
 
+    def get_arp_flood(self):
+        """
+        Get the ARP flooding policy for this BD
+
+        :returns: a string containing the ARP flooding policy of the BridgeDomain
+        """
+        return self.arp_flood
+
     def set_unicast_route(self, route):
         """
         Set the unicast route for this BD
@@ -1811,6 +1828,14 @@ class BridgeDomain(BaseACIObject):
         Check if unicast routing is enabled
         """
         return self.unicast_route == 'yes'
+
+    def get_unicast_route(self):
+        """
+        Get the Unicast Routing policy for this BD
+
+        :returns: a string containing the unicast routing policy of the BridgeDomain
+        """
+        return self.unicast_route
 
     def set_multidestination(self, multidestination):
         """


### PR DESCRIPTION
[Resubmitting this PR so it can be merged straight away. Previous one conflicted.]

Add a few missing methods to the toolkit, for completeness and consistency. Note that some of the methods requested can be considered redundant (e.g. get_arp_flood() when is_arp_flood() already exists). The reason why they were added is because that allows an application to retrieve state of the policy and push it to a different APIC without having to figure out what kind of parameter needs to be passed to the setter (e.g otherwise one needs to figure out what value needs to be passed to "set_arp_flood() when is_arp_flood() returns True. In this case, we'd need to pass "yes" to the setter, making it slightly harder to code it).