### PR TITLE
Improve VPC path generation

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -3165,6 +3165,10 @@ class PortChannel(BaseInterface):
         pod = self._interfaces[0].pod
         if self.is_vpc():
             (node1, node2) = self._get_nodes()
+            # Make sure the order of the nodes is the right one (lowest numbered
+            # first)
+            if int(node1)>int(node2):
+                node1, node2 = node2, node1
             path = 'topology/pod-%s/protpaths-%s-%s/pathep-[%s]' % (pod,
                                                                     node1,
                                                                     node2,


### PR DESCRIPTION
Make VPC path generation deterministic by always using the lowest node id first. Currently, this is left to the way Python would construct a set. Code doing that is the following:

```
    def _update_nodes(self):
        """Updates the nodes that are participating in this PortChannel"""
        nodes = []
        for interface in self._interfaces:
            nodes.append(interface.node)
        self._nodes = set(nodes)
```

This patch modifies _get_path() so the nodes are sorted if they weren't.
