### PR TITLE
Fixes #61, print Statement fix for python3

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -145,7 +145,7 @@ class Tenant(BaseACIObject):
                 'vzBrCP': Contract,
                 'vzFilter': Filter,
                 'vzTaboo': Taboo,
-                'l3extOut': OutsideEPG}
+                'l3extOut': OutsideL3}
 
     @classmethod
     def get_deep(cls, session, names=(), limit_to=(), subtree='full', config_only=False, parent=None):
@@ -1890,6 +1890,15 @@ class BridgeDomain(BaseACIObject):
                             for context in objs:
                                 if isinstance(context, Context):
                                     self.add_context(context)
+                        elif 'fvRsBDToOut' in bd_child:
+                            l3_out_name = bd_child['fvRsBDToOut']['attributes']['tnL3extOutName']
+                            tenant = self.get_parent()
+                            l3_out_search = Search()
+                            l3_out_search.name = l3_out_name
+                            objs = tenant.find(l3_out_search)
+                            for l3_out in objs:
+                                if isinstance(l3_out, OutsideL3):
+                                    self.add_l3out(l3_out)
                     break
         super(BridgeDomain, self)._extract_relationships(data)
 
@@ -1930,21 +1939,21 @@ class BridgeDomain(BaseACIObject):
     def add_l3out(self, l3out):
         """
         Set the L3Out for this BD
-        :param l3out: OutsideEPG to assign this BridgeDomain
+        :param l3out: OutsideL3 to assign this BridgeDomain
 
         """
-        if not isinstance(l3out, OutsideEPG):
-            raise TypeError('add_l3out not called with OutsideEPG')
+        if not isinstance(l3out, OutsideL3):
+            raise TypeError('add_l3out not called with OutsideL3')
         self._add_relation(l3out)
 
     def has_l3out(self):
-        return len(self._get_all_relation(OutsideEPG)) > 0
+        return len(self._get_all_relation(OutsideL3)) > 0
 
     def get_l3out(self):
         """
-        :returns: List of OutsideEPG objects
+        :returns: List of OutsideL3 objects
         """
-        return self._get_all_relation(OutsideEPG)
+        return self._get_all_relation(OutsideL3)
 
     # Subnet
     def add_subnet(self, subnet):

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -3337,6 +3337,7 @@ if __name__ == '__main__':
     live.addTest(unittest.makeSuite(TestLiveSubscription))
     live.addTest(unittest.makeSuite(TestLiveOSPF))
     live.addTest(unittest.makeSuite(TestLiveMonitorPolicy))
+    live.addTest(unittest.makeSuite(TestLiveOutsideL3))
 
     offline = unittest.TestSuite()
     offline.addTest(unittest.makeSuite(TestBaseRelation))
@@ -3369,6 +3370,5 @@ if __name__ == '__main__':
     # Add tests to this suite while developing the tests
     # This allows only these tests to be run
     develop = unittest.TestSuite()
-    develop.addTest(unittest.makeSuite(TestLiveOutsideL3))
 
-    unittest.main(defaultTest='develop')
+    unittest.main(defaultTest='offline')

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -52,12 +52,12 @@ try:
     from credentials import URL, LOGIN, PASSWORD
 except ImportError:
     print
-    print 'To run live tests, please create a credentials.py file with the following variables filled in:'
-    print """
+    print('To run live tests, please create a credentials.py file with the following variables filled in:')
+    print("""
     URL = ''
     LOGIN = ''
     PASSWORD = ''
-    """
+    """)
 
 MAX_RANDOM_STRING_SIZE = 20
 


### PR DESCRIPTION
Related to Point  '- Associated L3 Outs: (Name)' of Issue #61
There was already an 'add_l3out' implementation that referenced to OutsideEPG. I changed this to OutsideL3 and added a proper resolution to the BridgeDomain class.