### PR TITLE
Fix #173, dont overwrite EPG name field if attribute list has empty/no value

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -924,7 +924,8 @@ class EPG(CommonEPG):
         self.match_type = str(attributes.get('matchT'))
         self.class_id = str(attributes.get('pcTag'))
         self.scope = str(attributes.get('scope'))
-        self.name = str(attributes.get('name'))
+        if 'name' in attributes:
+            self.name = str(attributes.get('name'))
         self._is_attribute_based = str(attributes.get('isAttrBasedEPg'))
         if self._is_attribute_based.lower() in ['true', 'yes']:
             self._is_attribute_based = True


### PR DESCRIPTION
This PR is in reference to issue #173.

Check whether the name field in the attribute dictionary is populated before over writing the objects field.