### PR TITLE
changes to keep the local database in search application in sync with…

### DIFF
--- a/acitoolkit/aciConcreteLib.py
+++ b/acitoolkit/aciConcreteLib.py
@@ -152,6 +152,28 @@ class ConcreteArp(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/arp/inst')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/arp/inst')[1].split('/')[0]
+        return name
 
     @staticmethod
     def _get_children_concrete_classes():
@@ -277,6 +299,28 @@ class ConcreteArpDomain(CommonConcreteObject):
         :returns: class of parent object
         """
         return ConcreteArp
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/dom-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/dom-')[1].split('/')[0]
+        return name
 
     @staticmethod
     def _get_children_concrete_classes():
@@ -381,6 +425,28 @@ class ConcreteArpEntry(CommonConcreteObject) :
         resp = ['arpAdjEp','arpDb']
 
         return resp
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/adj-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/adj-')[1].split('/')[0]
+        return name
 
     @classmethod
     def get(cls, working_data, parent):
@@ -438,6 +504,28 @@ class ConcreteVpc(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/vpc')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/vpc')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -768,6 +856,39 @@ class ConcreteContext(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        if '/inst-' in dn :
+            return dn.split('/sys/inst-')[0]
+        elif '/ctx-' in dn :
+            return dn.split('/sys/ctx-')[0]
+        else:
+            return None
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        if '/inst-' in dn :
+            name = dn.split('/sys/inst-')[1].split('/')[0]
+            return name
+        elif '/ctx-' in dn :
+            name = dn.split('/sys/ctx-')[1].split('/')[0]
+            return name
+        else:
+            return None
 
     @classmethod
     def _get_apic_classes(cls):
@@ -900,6 +1021,28 @@ class ConcreteSVI(CommonConcreteObject):
         :returns: class of parent object
         """
         return ConcreteBD
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/svi-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/svi-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1026,6 +1169,28 @@ class ConcreteLoopback(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/lb-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/lb-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1111,6 +1276,28 @@ class ConcreteBD(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1546,6 +1733,29 @@ class ConcreteFilter(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/actrl/filt-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/actrl/filt-')[1].split('/')[0]
+        return name
+
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1809,6 +2019,31 @@ class ConcreteEp(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/ctx-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/ctx-')[1].split('/')[0]
+        return name
+    
+    
 
     @classmethod
     def _get_apic_classes(cls):
@@ -2182,6 +2417,28 @@ class ConcretePortChannel(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/aggr-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/aggr-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -2393,6 +2650,28 @@ class ConcreteTunnel(CommonConcreteObject):
         :returns: class of parent object
         """
         return ConcreteOverlay
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/tunnel-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/tunnel-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -2537,6 +2816,29 @@ class ConcreteOverlay(CommonConcreteObject):
         :returns: class of parent object
         """
         return Node
+    
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/overlay')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/overlay')[1].split('/')[0]
+        return name
 
     @staticmethod
     def _get_children_concrete_classes():

--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -353,7 +353,15 @@ class BaseACIObject(AciSearch):
         parent_class = cls._get_parent_class()
         if parent_class is None:
             return None
-        parent_name = parent_class._get_name_from_dn(dn)
+        if type(parent_class) is list :
+            for parent_class_name in parent_class:
+                if not parent_class_name._get_name_from_dn(dn) is None:
+                    parent_name = parent_class_name._get_name_from_dn(dn)
+                    if parent_name != None:
+                        parent_class = parent_class_name
+                        break
+        else :
+            parent_name = parent_class._get_name_from_dn(dn)
         parent_dn = cls._get_parent_dn(dn)
         parent_obj = parent_class(parent_name,
                                   parent_class._get_parent_from_dn(parent_dn))
@@ -413,8 +421,8 @@ class BaseACIObject(AciSearch):
             resp = session.subscribe(url, only_new=only_new)
             if resp is not None:
                 if not resp.ok:
-                    return resp
-        return resp
+                    return False
+        return True
 
     @classmethod
     def get_event(cls, session):
@@ -718,6 +726,29 @@ class BaseACIObject(AciSearch):
                 child.populate_children(deep, include_concrete)
 
         return self._children
+    
+    def update_db(self, session,subscribed_classes,deep=False):
+        for child_class in self._get_children_classes():
+            child_class.subscribe(session,only_new=True)
+            if not child_class in subscribed_classes:
+                subscribed_classes.append(child_class)
+                
+        for child_class in self._get_toolkit_to_apic_classmap():
+            subscribed_classes.append(self._get_toolkit_to_apic_classmap().get(child_class))
+            self._get_toolkit_to_apic_classmap().get(child_class).subscribe(session,only_new=True)
+            
+        if deep:
+            for child in self._children:
+                subscribed_classes = child.update_db(session,subscribed_classes,deep)
+            '''
+            if len(self._children) >0 :
+                for child in self._children:
+                    subscribed_classes = child.update_db(session,subscribed_classes,deep)
+            else :
+                subscribed_classes.append(self)
+                self.subscribe(session,only_new=True)
+            '''
+        return subscribed_classes
 
     def get_parent(self):
         """

--- a/acitoolkit/aciphysobject.py
+++ b/acitoolkit/aciphysobject.py
@@ -83,6 +83,28 @@ class Systemcontroller(BaseACIPhysModule):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/ch/bslot/board')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/ch/bslot/board')[1].split('/')[0]
+        return name
 
     @classmethod
     def get(cls, session, parent=None):
@@ -286,6 +308,17 @@ class Linecard(BaseACIPhysModule):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/lc-')[0]
 
     @staticmethod
     def _get_children_classes():
@@ -412,6 +445,28 @@ class Supervisorcard(BaseACIPhysModule):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/sys/ch/supslot-1/sup')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/sys/ch/supslot-1/sup')[1].split('/')[0]
+        return name
 
     @classmethod
     def get(cls, session, parent_node=None):
@@ -536,6 +591,28 @@ class Fantray(BaseACIPhysModule):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/ft-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/ft-')[1].split('/')[0]
+        return name
 
     @staticmethod
     def _get_children_classes():
@@ -679,6 +756,28 @@ class Fan(BaseACIPhysModule):
         """
         return Fantray
 
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/fan-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/fan-')[1].split('/')[0]
+        return name
+    
     @classmethod
     def get(cls, session, parent=None):
         """Gets all of the fans from the APIC.  If parent
@@ -830,6 +929,28 @@ class Powersupply(BaseACIPhysModule):
         :returns: class of parent object
         """
         return Node
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/psu-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/psu-')[1].split('/')[0]
+        return name
 
     @classmethod
     def get(cls, session, parent=None):
@@ -952,6 +1073,28 @@ class Pod(BaseACIPhysObject):
         :returns: class of parent object
         """
         return PhysicalModel
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/pod-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/pod-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1084,6 +1227,104 @@ class Node(BaseACIPhysObject):
         :returns: class of parent object
         """
         return Pod
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/node-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/node-')[1].split('/')[0]
+        return name
+    
+    @classmethod
+    def get_event(cls, session):
+        """
+        Gets the event that is pending for this class.  Events are
+        returned in the form of objects.  Objects that have been deleted
+        are marked as such.
+
+        :param session:  the instance of Session used for APIC communication
+        """
+        urls = cls._get_subscription_urls()
+        for url in urls:
+            if not session.has_events(url):
+                continue
+            event = session.get_event(url)
+            for class_name in cls._get_apic_classes():
+                if class_name in event['imdata'][0]:
+                    break
+            attributes = event['imdata'][0][class_name]['attributes']
+            status = str(attributes['status'])
+            dn = str(attributes['dn'])
+            pod_id,node_id = Node._parse_dn(dn)
+            
+            node_dn = 'topology/pod-{0}/node-{1}'.format(pod_id, node_id)
+            base_url = '/api/mo/' + node_dn + '.json?'
+            working_data = WorkingData(session, Node, base_url)
+
+            parent = cls._get_parent_from_dn(cls._get_parent_dn(dn))
+
+            data = working_data.get_class('fabricNode')
+            for apic_node in data:
+                if 'fabricNode' in apic_node:
+                    dist_name = str(apic_node['fabricNode']['attributes']['dn'])
+                    node_name = str(apic_node['fabricNode']['attributes']['name'])
+                    (pod, node_id) = cls._parse_dn(dist_name)
+                    node_role = str(apic_node['fabricNode']['attributes']['role'])
+                    node = cls(pod, node_id, node_name, node_role)
+                    node._session = session
+                    node._populate_from_attributes(apic_node['fabricNode']['attributes'])
+                    node._get_topsystem_info(working_data)
+
+                    # check for pod match if specified
+                    pod_match = False
+                    if parent:
+                        if isinstance(parent, Pod):
+                            if node.pod == parent.pod:
+                                pod_match = True
+                                node._parent = parent
+                        else:
+                            # pod is a number string
+                            if node.pod == parent:
+                                pod_match = True
+                    else:
+                        pod_match = True
+
+                    # check for node match if specified
+                    node_match = False
+                    if node_id:
+                        if node_id == node.node:
+                            node_match = True
+                    else:
+                        node_match = True
+
+                    if node_match and pod_match:
+                        if node.role == 'leaf':
+                            node._add_vpc_info(working_data)
+                        node.get_health()
+                        node.get_firmware(working_data)
+
+                        if isinstance(parent, Pod):
+                            node._parent.add_child(node)
+
+                    if status == 'deleted':
+                        node.mark_as_deleted()
+                    return node
+
 
     @staticmethod
     def _get_children_classes():
@@ -1639,6 +1880,28 @@ class ExternalSwitch(BaseACIPhysObject):
         :returns: class of parent object
         """
         return Pod
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        if 'comp/' in dn:
+            return dn.split('comp/prov-VMware/ctrlr-[DC1]-vcenter1/hv-')[0]
+        else:
+            return dn.split('topology/lsnode-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        if 'comp/' in dn:
+            name = dn.split('comp/prov-VMware/ctrlr-[DC1]-vcenter1/hv-')[1]
+        else:
+            name = dn.split('topology/lsnode-')[1]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -1674,6 +1937,39 @@ class ExternalSwitch(BaseACIPhysObject):
         if value not in valid_roles:
             raise ValueError("role must be one of " + str(valid_roles) + ' found ' + str(value))
         self._role = value
+        
+    @classmethod
+    def get_event(cls, session):
+        """
+        not yet fully implemented
+        """
+        urls = cls._get_subscription_urls()
+        for url in urls:
+            if not session.has_events(url):
+                continue
+            event = session.get_event(url)
+            for class_name in cls._get_apic_classes():
+                if class_name in event['imdata'][0]:
+                    break
+            if class_name == "fabricLooseNode" or class_name == "compHv":
+                attributes = event['imdata'][0][class_name]['attributes']
+                status = str(attributes['status'])
+                dn = str(attributes['dn'])
+                if status == 'created':
+                    name = str(attributes['name'])
+                else:
+                    name = cls._get_name_from_dn(dn)
+                obj = cls(name, parent=None)
+                if url == "/api/class/fabricLooseNode.json?subscription=yes" :
+                    obj._populate_physical_from_attributes(attributes)
+                elif url == "/api/class/compHv.json?subscription=yes" :
+                    obj._populate_virtual_from_attributes(attributes)
+                obj._get_system_info(session)
+                if status == 'deleted':
+                    obj.mark_as_deleted()
+                return obj
+            return
+
 
     @classmethod
     def _get_physical_switches(cls, session, parent):
@@ -2130,6 +2426,28 @@ class Link(BaseACIPhysObject):
         link = str(name[2].split('-')[1])
 
         return pod, link
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/lnkcnt-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/lnkcnt-')[1].split('/')[0]
+        return name
 
 
 class Interface(BaseInterface):
@@ -2532,6 +2850,28 @@ class Interface(BaseInterface):
         :returns: class of parent object
         """
         return Linecard
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('/phys-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/phys-')[1].split('/')[0]
+        return name
 
     @classmethod
     def _get_apic_classes(cls):
@@ -2761,11 +3101,11 @@ class WorkingData(object):
             self.rawjson = ret.json()['imdata']
         else:
             self.rawjson = None
+        if not self.rawjson is None:
+            if 'error' not in self.rawjson:
+                self._index_objects()
 
-        if 'error' not in self.rawjson:
-            self._index_objects()
-
-            self.build_vnid_dictionary()
+                self.build_vnid_dictionary()
 
     def _index_objects(self):
         """
@@ -3063,6 +3403,28 @@ class PhysicalModel(BaseACIObject):
         :returns: class of parent object
         """
         return Fabric
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Gets the dn of the parent object
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: string containing dn
+        """
+        return dn.split('topology')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('topology')[1].split('/')[0]
+        return name
 
     @staticmethod
     def _get_children_classes():
@@ -3073,6 +3435,17 @@ class PhysicalModel(BaseACIObject):
         :return: list of classes
         """
         return [Pod]
+    
+    @classmethod
+    def _get_apic_classes(cls):
+        """
+        Get the APIC classes used by the acitoolkit class.
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: list of strings containing APIC class names
+        """
+        return []
 
     @classmethod
     def get(cls, session=None, parent=None):
@@ -3107,13 +3480,13 @@ class Fabric(BaseACIObject):
     From this class, you can populate all of the children classes.
     """
 
-    def __init__(self, session=None):
+    def __init__(self, session=None,parent=None):
         """
         Initialization method that sets up the Fabric.
         :return:
         """
-        if session:
-            assert isinstance(session, Session)
+        #if session:
+        #  assert isinstance(session, Session)
 
         super(Fabric, self).__init__(name='', parent=None)
 
@@ -3128,6 +3501,37 @@ class Fabric(BaseACIObject):
         :returns: class of parent object
         """
         return None
+    
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        return 'Fabric'
+
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return None
+    
+    @classmethod
+    def _get_apic_classes(cls):
+        """
+        Get the APIC classes used by the acitoolkit class.
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: list of strings containing APIC class names
+        """
+        return []
 
     @classmethod
     def get(cls, session):

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -78,8 +78,8 @@ class Tenant(BaseACIObject):
         :param parent: None or An instance of Fabric class representing the Pod
                        which contains this Tenant.
         """
-        if parent is not None and not isinstance(parent, Fabric):
-            raise TypeError('Parent must be None or an instance of Fabric class')
+        #if parent is not None and not isinstance(parent, Fabric):
+        #    raise TypeError('Parent must be None or an instance of Fabric class')
         super(Tenant, self).__init__(name, parent)
 
     @classmethod
@@ -112,7 +112,7 @@ class Tenant(BaseACIObject):
         :param dn: string containing the distinguished name URL
         :return: string containing the name
         """
-        name = dn.split('uni/tn-')[1].split('/')[0]
+        name = dn.split('/tn-')[1].split('/')[0]
         return name
 
     @staticmethod
@@ -123,7 +123,8 @@ class Tenant(BaseACIObject):
         :param dn: string containing the distinguished name URL
         :return: None
         """
-        return None
+        return dn.split('/tn-')[0]
+
 
     def get_json(self):
         """
@@ -343,6 +344,12 @@ class AppProfile(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/ap-')[0]
 
     @staticmethod
@@ -767,6 +774,27 @@ class AttributeCriterion(BaseACIObject):
         :returns: class of parent object
         """
         return EPG
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/crtrn')[0]
+    
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/crtrn')[1].split('/')[0]
+        return name
 
     @property
     def match(self):
@@ -926,6 +954,12 @@ class EPG(CommonEPG):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/epg-')[0]
 
     @staticmethod
@@ -1477,6 +1511,27 @@ class OutsideEPG(CommonEPG):
                                     self.consume_cif(contract_if)
 
         super(OutsideEPG, self)._extract_relationships(data, obj_dict)
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/instP-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/instP-')[1].split('/')[0]
+        return name
 
 
 class AnyEPG(CommonEPG):
@@ -1602,6 +1657,27 @@ class AnyEPG(CommonEPG):
             text = {'vzRsAnyToConsIf': {'attributes': {'status': 'deleted', 'tnVzCPIfName': contract_interface.name}}}
             children.append(text)
         return children
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/any')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/any')[1].split('/')[0]
+        return name
 
 
 class OutsideL2EPG(CommonEPG):
@@ -1640,10 +1716,22 @@ class OutsideL2EPG(CommonEPG):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/instP-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         return dn.split('/instP-')[1].split('/')[0]
 
     def _extract_relationships(self, data, obj_dict):
@@ -1816,6 +1904,26 @@ class OutsideL3(BaseACIObject):
         return super(OutsideL3, self).get_json('l3extOut',
                                                attributes=attr,
                                                children=children)
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/out-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        return dn.split('/out-')[1].split('/')[0]
 
 
 class OutsideL2(BaseACIObject):
@@ -1841,6 +1949,12 @@ class OutsideL2(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/l2out-')[0]
 
     @staticmethod
@@ -2424,10 +2538,22 @@ class BridgeDomain(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/BD-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         return dn.split('/BD-')[1].split('/')[0]
 
     def set_unknown_mac_unicast(self, unicast):
@@ -3012,7 +3138,60 @@ class Subnet(BaseSubnet):
         result['addr'] = self.get_addr()
         result['scope'] = self.get_scope()
         return result
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
 
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/subnet-[')[0]
+    
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/subnet-[')[1].split('/')[0]
+        return name
+    
+    @classmethod
+    def get_event(cls, session):
+        """
+        Gets the event that is pending for this class.  Events are
+        returned in the form of objects.  Objects that have been deleted
+        are marked as such.
+
+        :param session:  the instance of Session used for APIC communication
+        """
+        urls = cls._get_subscription_urls()
+        for url in urls:
+            if not session.has_events(url):
+                continue
+            event = session.get_event(url)
+            for class_name in cls._get_apic_classes():
+                if class_name in event['imdata'][0]:
+                    break
+            attributes = event['imdata'][0][class_name]['attributes']
+            status = str(attributes['status'])
+            dn = str(attributes['dn'])
+            if not "/BD-" in cls._get_parent_dn(dn):
+                return
+            parent = cls._get_parent_from_dn(cls._get_parent_dn(dn))
+            if status == 'created':
+                name = str(attributes['name'])
+            else:
+                name = cls._get_name_from_dn(dn)
+            obj = cls(name, parent=parent)
+            obj._populate_from_attributes(attributes)
+            if status == 'deleted':
+                obj.mark_as_deleted()
+            return obj
 
 class OutsideNetwork(BaseSubnet):
     """
@@ -3029,6 +3208,28 @@ class OutsideNetwork(BaseSubnet):
         :returns: class of parent object
         """
         return OutsideEPG
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/extsubnet-[')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/extsubnet-[')[1].split('/')[0]
+        return name
+
 
     def _generate_attributes(self):
         attributes = super(OutsideNetwork, self)._generate_attributes()
@@ -3116,10 +3317,22 @@ class Context(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/ctx-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         return dn.split('/ctx-')[1].split('/')[0]
 
     @staticmethod
@@ -3329,10 +3542,22 @@ class ContractInterface(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/cif-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         return dn.split('/cif-')[1].split('/')[0]
 
     @staticmethod
@@ -3575,13 +3800,37 @@ class Contract(BaseContract):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/brc-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
-        name = dn.split('/brc-')[1].split('/')[0]
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        if '/brc-' in dn :
+            name = dn.split('/brc-')[1].split('/')[0]
+        elif '/oobbrc-' in dn :
+            name = dn.split('/oobbrc-')[1].split('/')[0]
         return name
 
+    @staticmethod
+    def _get_parent_class():
+        """
+        Gets the class of the parent object
+
+        :returns: class of parent object
+        """
+        return Tenant
+    
     def _generate_attributes(self):
         attributes = super(Contract, self)._generate_attributes()
         attributes['scope'] = self.get_scope()
@@ -3772,6 +4021,30 @@ class ContractSubject(BaseACIObject):
             if isinstance(relation.item, Filter):
                 resp.append(relation.item)
         return resp
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/subj-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        if '/subj-' in dn :
+            name = dn.split('/subj-')[1].split('/')[0]
+            return name
+        else :
+            return None
 
 
 class Filter(BaseACIObject):
@@ -3853,6 +4126,27 @@ class Filter(BaseACIObject):
         resp_json['vzFilter']['children'] = filter_entries
         return resp_json
 
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/flt-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/flt-')[1].split('/')[0]
+        return name
+
 
 class Taboo(BaseContract):
     """ Taboo :  Class for Taboos """
@@ -3879,10 +4173,22 @@ class Taboo(BaseContract):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/taboo-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         name = dn.split('/taboo-')[1].split('/')[0]
         return name
 
@@ -4135,6 +4441,38 @@ class FilterEntry(BaseACIObject):
                 'prot', 'sFromPort', 'sToPort', 'tcpRules', 'stateful')
             return key_attrs(self) == key_attrs(other)
         return NotImplemented
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/e-')[0]
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/e-')[1].split('/')[0]
+        return name
+    
+    @classmethod
+    def _get_apic_classes(cls):
+        """
+        Get the APIC classes used by the acitoolkit class.
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: list of strings containing APIC class names
+        """
+        return []
 
 
 class BaseTerminal(BaseACIObject):
@@ -4271,6 +4609,37 @@ class InputTerminal(BaseTerminal):
         :returns: String containing APIC class name for this type of terminal.
         """
         return 'vzInTerm'
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/intmnl')[0]
+
+    @staticmethod
+    def _get_parent_class():
+        """
+        Gets the class of the parent object
+
+        :returns: class of parent object
+        """
+        return ContractSubject
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/intmnl')[1].split('/')[0]
+        return name
+
 
 class OutputTerminal(BaseTerminal):
     """
@@ -4285,6 +4654,36 @@ class OutputTerminal(BaseTerminal):
         :returns: String containing APIC class name for this type of terminal.
         """
         return 'vzOutTerm'
+    
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('/outtmnl')[0]
+
+    @staticmethod
+    def _get_parent_class():
+        """
+        Gets the class of the parent object
+
+        :returns: class of parent object
+        """
+        return ContractSubject
+
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('/outtmnl')[1].split('/')[0]
+        return name
 
 
 class TunnelInterface(object):
@@ -4559,6 +4958,12 @@ class Endpoint(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         if '/stcep-' in dn:
             return dn.split('/stcep-')[0]
         else:
@@ -4948,10 +5353,22 @@ class IPEndpoint(BaseACIObject):
 
     @staticmethod
     def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
         return dn.split('/ip-')[0]
 
     @staticmethod
     def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
+
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
         return dn.split('/ip-[')[1].split(']')[0]
 
     def get_json(self):
@@ -5702,15 +6119,6 @@ class EPGDomain(BaseACIObject):
             attributes['childAction'] = self.childAction
 
         return attributes
-
-    @classmethod
-    def _get_apic_classes(cls):
-        """
-        Get the APIC classes used by this acitoolkit class.
-
-        :returns: list of strings containing APIC class names
-        """
-        return ['fvRsDomAtt']
 
     def get_parent(self):
         """
@@ -6692,7 +7100,28 @@ class LogicalModel(BaseACIObject):
         :returns: class of parent object
         """
         return Fabric
+    
+    @staticmethod
+    def _get_name_from_dn(dn):
+        """
+        Get the instance name from the dn
 
+        :param dn: string containing the distinguished name URL
+        :return: string containing the name
+        """
+        name = dn.split('uni')[1].split('/')[0]
+        return name
+
+    @staticmethod
+    def _get_parent_dn(dn):
+        """
+        Get the parent DN
+
+        :param dn: string containing the distinguished name URL
+        :return: None
+        """
+        return dn.split('uni')[0]
+    
     @classmethod
     def get(cls, session=None, parent=None):
         """
@@ -6713,6 +7142,17 @@ class LogicalModel(BaseACIObject):
         :return: list of classes
         """
         return [Tenant]
+    
+    @classmethod
+    def _get_apic_classes(cls):
+        """
+        Get the APIC classes used by the acitoolkit class.
+        Meant to be overridden by inheriting classes.
+        Raises exception if not overridden.
+
+        :returns: list of strings containing APIC class names
+        """
+        return []
 
     def populate_children(self, deep=False, include_concrete=False):
         """
@@ -6733,7 +7173,7 @@ class LogicalModel(BaseACIObject):
                 child_class.get(self._session, self)
 
         return self._children
-
+    
     def _define_searchables(self):
         """
         Create all of the searchable terms

--- a/applications/search/aciSearch_update_local_database_test.py
+++ b/applications/search/aciSearch_update_local_database_test.py
@@ -1,0 +1,299 @@
+from acitoolkit.acisession import Session
+import unittest
+import sys
+import time
+import sqlite3
+
+from acitoolkit.acitoolkit import *
+from acitoolkit.aciphysobject import *
+
+class TestTenantUpdateInDatabase(unittest.TestCase):
+    def setUp(self):
+        session = Session("http://172.31.216.100", "admin", "ins3965!")
+        try:
+            resp = session.login()
+            self.session = session
+            print resp
+            if not resp.ok:
+                print('%% Could not login to APIC')
+                sys.exit(0)
+        except :
+            print "unable to login"
+        conn = sqlite3.connect("searchdatabase.db")
+        self.conn = conn.cursor()
+        
+    def test_addNewTenant(self):
+        tenant = Tenant('test_Tenant')
+        self.assertNotEqual(tenant, None)
+        app = AppProfile('test_App', tenant)
+        self.assertNotEqual(app, None)
+        epg = EPG('test_epg', app)
+        self.assertNotEqual(epg, None)
+        endpoint = Endpoint("00-11-22-33-44-55", epg)
+        self.assertNotEqual(endpoint, None)
+        attributeCriterion = AttributeCriterion('test_attr', epg)
+        self.assertNotEqual(attributeCriterion, None)
+        
+        
+        bridgeDomain = BridgeDomain('test_BridgeDomain', tenant)
+        self.assertNotEqual(bridgeDomain, None)
+        subnet = Subnet('test_subnet',bridgeDomain)
+        subnet.set_addr('1.1.1.1/24')
+        self.assertNotEqual(subnet, None)
+        
+        contractInterface = ContractInterface('test_ContractInterface', tenant)
+        self.assertNotEqual(contractInterface, None)
+        context = Context('test_Context', tenant)
+        self.assertNotEqual(context, None)
+        any_epg = AnyEPG('test_anyEPG', context)
+        self.assertTrue(isinstance(any_epg, AnyEPG))
+        
+        contract = Contract('test_Contract', tenant)
+        self.assertNotEqual(contract, None)
+        contractSubject = ContractSubject('test_ContractSubject',contract)
+        self.assertTrue(isinstance(contractSubject, ContractSubject))
+        
+        filter = Filter('test_Filter', tenant)
+        self.assertNotEqual(filter, None)
+        filt_entry = FilterEntry("test_filter_entry", filter)
+        self.assertTrue(isinstance(filt_entry, FilterEntry))
+
+       
+        taboo = Taboo('test_Taboo', tenant)
+        self.assertNotEqual(taboo, None)
+        
+        outsideL3 = OutsideL3('test_OutsideL3', tenant)
+        self.assertNotEqual(outsideL3, None)
+        self.assertTrue(isinstance(outsideL3, OutsideL3))
+        
+        outside_epg = OutsideEPG('test_outsideEPG', outsideL3)
+        self.assertTrue(isinstance(outside_epg, OutsideEPG))
+        outsideNetwork = OutsideNetwork('5.1.1.1', outside_epg)
+        outsideNetwork.ip = '5.1.1.1/8'
+        self.assertTrue(isinstance(outsideNetwork, OutsideNetwork))
+        
+        output_terminal = OutputTerminal('test_OutputTerminal',contractSubject)
+        self.assertTrue(isinstance(output_terminal, OutputTerminal))
+        
+        resp = self.session.push_to_apic(tenant.get_url(), data=tenant.get_json())
+        if resp.ok:
+            print 'Success'
+        
+        time.sleep(10)
+        self.conn.execute("SELECT * FROM avc where class='Tenant' and attribute='name' and value='test_Tenant'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding tenant")
+        self.assertTrue(result[0][1]=="test_Tenant", "value didnot match for the added tenant")
+        
+        self.conn.execute("SELECT * FROM avc where class='AppProfile' and attribute='name' and value='test_App'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding AppProfile")
+        self.assertTrue(result[0][1]=="test_App", "value didnot match for the added AppProfile")
+        
+        self.conn.execute("SELECT * FROM avc where class='EPG' and attribute='name' and value='test_epg'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Epg")
+        self.assertTrue(result[0][1]=="test_epg", "value didnot match for the added epg")
+        
+        self.conn.execute("SELECT * FROM avc where class='Endpoint' and attribute='name'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Endpoint")
+        
+        self.conn.execute("SELECT * FROM avc where class='AttributeCriterion' and attribute='name' and value='test_attr'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding AttributeCriterion")
+        self.assertTrue(result[0][1]=="test_attr", "value didnot match for the added AttributeCriterion")
+        
+        self.conn.execute("SELECT * FROM avc where class='BridgeDomain' and attribute='name' and value='test_BridgeDomain'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding BridgeDomain")
+        self.assertTrue(result[0][1]=="test_BridgeDomain", "value didnot match for the added BridgeDomain")
+        
+        self.conn.execute("SELECT * FROM avc where class='Taboo' and attribute='name' and value='test_Taboo'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Taboo")
+        self.assertTrue(result[0][1]=="test_Taboo", "value didnot match for the added Taboo")
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideL3' and attribute='name' and value='test_OutsideL3'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding OutsideL3")
+        self.assertTrue(result[0][1]=="test_OutsideL3", "value didnot match for the added OutsideL3")
+        
+        self.conn.execute("SELECT * FROM avc where class='Filter' and attribute='name' and value='test_Filter'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Filter")
+        self.assertTrue(result[0][1]=="test_Filter", "value didnot match for the added Filter")
+        
+        self.conn.execute("SELECT * FROM avc where class='Context' and attribute='name' and value='test_Context'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Context")
+        self.assertTrue(result[0][1]=="test_Context", "value didnot match for the added Context")
+        
+        self.conn.execute("SELECT * FROM avc where class='Contract' and attribute='name' and value='test_Contract'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Contract")
+        self.assertTrue(result[0][1]=="test_Contract", "value didnot match for the added Contract")
+        
+        self.conn.execute("SELECT * FROM avc where class='ContractInterface' and attribute='name' and value='test_ContractInterface'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding ContractInterface")
+        self.assertTrue(result[0][1]=="test_ContractInterface", "value didnot match for the added ContractInterface")
+        
+        self.conn.execute("SELECT * FROM avc where class='AnyEPG' and attribute='name' and uid='uni/tn-test_Tenant/ctx-test_Context/any'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding AnyEPG")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='Subnet' and attribute='name' and value='test_subnet'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding Subnet")
+        self.assertTrue(result[0][1]=="test_subnet", "value didnot match for the added Subnet")
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideEPG' and attribute='name' and value='test_outsideEPG'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding OutsideEPG")
+        self.assertTrue(result[0][1]=="test_outsideEPG", "value didnot match for the added OutsideEPG")
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideNetwork' and attribute='name' and value='5.1.1.1'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding OutsideNetwork")
+        self.assertTrue(result[0][1]=="5.1.1.1", "value didnot match for the added OutsideNetwork")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='ContractSubject' and attribute='name' and value='test_ContractSubject'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding ContractSubject")
+        self.assertTrue(result[0][1]=="test_ContractSubject", "value didnot match for the added ContractSubject")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='OutputTerminal' and attribute='name' and value='test_OutputTerminal'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding OutputTerminal")
+        self.assertTrue(result[0][1]=="test_OutputTerminal", "value didnot match for the added OutputTerminal")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='FilterEntry' and attribute='name' and value='test_filter_entry'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(result>0, "successful in adding FilterEntry")
+        
+        app.mark_as_deleted()
+        epg.mark_as_deleted()
+        bridgeDomain.mark_as_deleted()
+        subnet.mark_as_deleted()
+        contractInterface.mark_as_deleted()
+        context.mark_as_deleted()
+        any_epg.mark_as_deleted()
+        contract.mark_as_deleted()
+        filter.mark_as_deleted()
+        contractSubject.mark_as_deleted()
+        taboo.mark_as_deleted()
+        outsideL3.mark_as_deleted()
+        outside_epg.mark_as_deleted()
+        outsideNetwork.mark_as_deleted()
+        
+        
+        attributeCriterion.mark_as_deleted()
+        endpoint.mark_as_deleted()
+        filt_entry.mark_as_deleted()
+        output_terminal.mark_as_deleted()
+        tenant.mark_as_deleted()
+        resp = self.session.push_to_apic(tenant.get_url(), data=tenant.get_json())
+        if resp.ok:
+            print 'Success'
+        
+        time.sleep(10)
+        self.conn.execute("SELECT * FROM avc where class='Tenant' and attribute='name' and value='test_Tenant'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting tenant")
+        
+        self.conn.execute("SELECT * FROM avc where class='AppProfile' and attribute='name' and value='test_App'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting appprofile")
+        
+        self.conn.execute("SELECT * FROM avc where class='EPG' and attribute='name' and value='test_epg'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting Epg")
+        
+        self.conn.execute("SELECT * FROM avc where class='BridgeDomain' and attribute='name' and value='test_BridgeDomain'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting BridgeDomain")
+        
+        self.conn.execute("SELECT * FROM avc where class='Taboo' and attribute='name' and value='test_Taboo'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting Taboo")
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideL3' and attribute='name' and value='test_OutsideL3'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting OutsideL3")
+        
+        self.conn.execute("SELECT * FROM avc where class='Filter' and attribute='name' and value='test_Filter'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting Filter")
+        
+        self.conn.execute("SELECT * FROM avc where class='Context' and attribute='name' and value='test_Context'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting Context")
+        
+        self.conn.execute("SELECT * FROM avc where class='Contract' and attribute='name' and value='test_Contract'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting Contract")
+        
+        self.conn.execute("SELECT * FROM avc where class='ContractInterface' and attribute='name' and value='test_ContractInterface'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting ContractInterface")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideEPG' and attribute='name' and value='test_outsideEPG'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting OutsideEPG")
+        
+        self.conn.execute("SELECT * FROM avc where class='OutsideNetwork' and attribute='name' and value='5.1.1.1'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting OutsideNetwork")
+        
+        
+        self.conn.execute("SELECT * FROM avc where class='ContractSubject' and attribute='name' and value='test_ContractSubject'")
+        result =  self.conn.fetchall()
+        
+        self.assertTrue(len(result)==0, "successful in deleting ContractSubject")
+
+        
+def main_test():
+    full = unittest.TestSuite()
+    full.addTest(unittest.makeSuite(TestTenantUpdateInDatabase))
+    unittest.main()
+    
+if __name__ == '__main__':
+    main_test()
+        


### PR DESCRIPTION
… the MIT updates on server and also a test case to check the events happening on tenant and update it in local database

In search application, as we get the database once from the server , it becomes stale if any changes happens to the MIB on the server side. To compensate this, implemented a daemon thread which subscribes to the MIB updates on the server and update the local database with the update events.

written a testcase to test this for MO in logicalModel.