### PR TITLE
Add lint application check for overlapping subnets.

### DIFF
--- a/applications/lint/acilint.py
+++ b/applications/lint/acilint.py
@@ -349,12 +349,12 @@ class Checker(object):
                                 # Because sometimes they are equal...
                                 self.output_handler("Error 005: In tenant/context '%s/%s': subnet %s in BridgeDomain "
                                                     "'%s' duplicated by subnet %s in BridgeDomain '%s'" % (
-                                                            tenant.name,
-                                                            current_context,
-                                                            ip_subnet.with_prefixlen,
-                                                            bd.name,
-                                                            address_list[index]['addr'].with_prefixlen,
-                                                            address_list[index]['bd']))
+                                                        tenant.name,
+                                                        current_context,
+                                                        ip_subnet.with_prefixlen,
+                                                        bd.name,
+                                                        address_list[index]['addr'].with_prefixlen,
+                                                        address_list[index]['bd']))
                         elif ip_subnet < address_list[index]['addr']:
                             index_to_insert = index+1
                             if ip_subnet.Contains(address_list[index]['addr']):
@@ -365,9 +365,9 @@ class Checker(object):
                                                                                  ip_subnet.with_prefixlen,
                                                                                  bd.name,
                                                                                  address_list[index - 1][
-                                                                                         'addr'].with_prefixlen,
+                                                                                     'addr'].with_prefixlen,
                                                                                  address_list[index - 1]['bd'],
-                                                                                 ))
+                                                                                ))
                             else:
                                 break
                         elif address_list[index]['addr'].Contains(ip_subnet):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
                       "tabulate",
                       "py-radix",
                       "jsonschema",
-                      "graphviz"],
+                      "graphviz",
+                      "ipaddr"],
     tests_requires=["mock"],
     description="This library allows basic Cisco ACI APIC configuration.",
 )


### PR DESCRIPTION
I added Error_005 to acilint.py to scan a fabric and identify any overlapping or duplicated subnets configured within a single Tenant/Context and updated setup.py to include the "ipaddr" module as a dependency as it is used for network subnet comparisons in the added error code.
