### PR TITLE
Added so that token is updated when aaaRefresh is used

### DIFF
--- a/acitoolkit/acisession.py
+++ b/acitoolkit/acisession.py
@@ -534,6 +534,8 @@ class Session(object):
         """
         refresh_url = '/api/aaaRefresh.json'
         resp = self.get(refresh_url, timeout=timeout)
+        ret_data = json.loads(resp.text)['imdata'][0]
+        self.token = str(ret_data['aaaLogin']['attributes']['token'])
         return resp
 
     def close(self):


### PR DESCRIPTION
You get a new token whenever aaaRefresh is used. Added so self.token gets updated every time the refresh_login method is used.

http://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/1-x/api/rest/b_APIC_RESTful_API_User_Guide/b_IFC_RESTful_API_User_Guide_chapter_010.html

 aaaRefresh—Sent as a GET message with no message body or as a POST message with the aaaLogin message body, this method resets the session timer. The response contains a new session token and cookie.