### PR TITLE
Commit to address Issue #200

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1212,6 +1212,8 @@ class EPG(CommonEPG):
 
             elif 'fvRsDomAtt' in child:
                 dom_attributes = child['fvRsDomAtt']['attributes']
+                dom = EPGDomain(dom_attributes['tDn'],self)
+                dom.tDn = dom_attributes['tDn']
                 self._dom_deployment_immediacy = dom_attributes['instrImedcy']
                 self._dom_resolution_immediacy = dom_attributes['resImedcy']
             elif 'fvRsConsIf' in child:

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -1132,7 +1132,7 @@ class EPG(CommonEPG):
                 encap = int_attributes['encap']
                 encap_type, encap_id = L2Interface.parse_encap(encap)
                 encap_mode = int_attributes['mode']
-                l2int = L2Interface('l2_int_{}-{}'.format(encap_type, encap_id),
+                l2int = L2Interface('l2_int_{}-{}_on_{}{}/{}/{}/{}'.format(encap_type, encap_id, int_type, pod, node, module, port),
                                     encap_type,
                                     encap_id,
                                     encap_mode)


### PR DESCRIPTION
This commit fixes #200.  Calling a get_deep on a Tenant did not fully populate the EPG’s children - specifically interface bindings and domain attachments.

Bindings fix:  When calling _extract_relationships on an EPG object in acitoolkit.py, if the EPG has multiple static bindings with the same vlan encapsulation, only one interface will be attached to the EPG.  This is because the L2Interface object name must be unique.  This fix updates the binding names so that they are unique.

Domain fix:  No domain object was created or attached when calling _extract_relationships.  Code to create and attach the domain was added.