### PR TITLE
Add operSpeed to the Interface.info() attributes.

### DIFF
--- a/acitoolkit/aciphysobject.py
+++ b/acitoolkit/aciphysobject.py
@@ -2985,6 +2985,7 @@ class Interface(BaseInterface):
                 (interface_type, pod, node,
                  module, port) = Interface.parse_dn(dist_name)
                 attributes['operSt'] = eth_data_dict[dist_name + '/phys']['operSt']
+                attributes['operSpeed'] = eth_data_dict[dist_name + '/phys']['operSpeed']
                 interface_obj = Interface(interface_type, pod, node, module, port,
                                           parent=None, session=session,
                                           attributes=attributes)


### PR DESCRIPTION
Sometimes the available "speed" has the value "inherit" which is not useful when you need to know the actual speed of an interface (such as when computing %utilization). This was the minimal change I could make to the core toolkit to get the actual speed of the interface. operSt was already there, so I just duplicated what was in there.