### PR TITLE
Error not finding parent in _get_parent_from_dn

### DIFF
--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -371,6 +371,11 @@ class BaseACIObject(AciSearch):
                     break
         else:
             parent_name = parent_class._get_name_from_dn(dn)
+
+        # if the parent_class is still a list, no class matches the DN
+        if type(parent_class) is list:
+            return None
+
         parent_dn = cls._get_parent_dn(dn)
         if parent_name is None:
             parent_obj = parent_class('')

--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -365,11 +365,10 @@ class BaseACIObject(AciSearch):
             return None
         if type(parent_class) is list:
             for parent_class_name in parent_class:
-                if not parent_class_name._get_name_from_dn(dn) is None:
-                    parent_name = parent_class_name._get_name_from_dn(dn)
-                    if parent_name is not None:
-                        parent_class = parent_class_name
-                        break
+                parent_name = parent_class_name._get_name_from_dn(dn)
+                if parent_name is not None:
+                    parent_class = parent_class_name
+                    break
         else:
             parent_name = parent_class._get_name_from_dn(dn)
         parent_dn = cls._get_parent_dn(dn)


### PR DESCRIPTION
This fixes an issue identified with the introduction of the `Tag` class.  

As a Tag can exist 'underneath' many different object types and acitookit has not yet implemented them all, there is a possibility that the function `_get_parent_from_dn` can cannot properly determine the parent object/name.  This PR does a check and returns `None` if the parent cannot be identified.

Maybe it might be a better idea to raise an error (ie, Not Implemented) or have a generic class that can handle this situation. Thoughts?