### PR TITLE
Intersite: skip endpoints that dont have accessable parent objects

### DIFF
--- a/applications/multisite/intersite.py
+++ b/applications/multisite/intersite.py
@@ -234,9 +234,12 @@ class EndpointHandler(object):
         :param endpoint: Instance of IPEndpoint
         :param local_site: Instance of LocalSite
         """
-        epg = endpoint.get_parent()
-        app = epg.get_parent()
-        tenant = app.get_parent()
+        try:
+            epg = endpoint.get_parent()
+            app = epg.get_parent()
+            tenant = app.get_parent()
+        except AttributeError as e:
+            return
         logging.info('endpoint: %s epg: %s app: %s tenant: %s', endpoint.name, epg.name, app.name, tenant.name)
 
         # Ignore events without IP addresses


### PR DESCRIPTION
Bit of an odd one.  Running Intersite with a minimal configuration, I am getting a crash in the [`add_endpoint`](https://github.com/datacenter/acitoolkit/blob/master/applications/multisite/intersite.py#L230) method of `EndpointHandler`.  A deeper inspection looks like the error is caused by the Endpoint subscriber picking up Service Graph related events.  From my understanding, these objects are not traditional endpoints/epg's/etc and do not really have an accessable parent object?

Here is an example output of the error occuring:
```
heylook:multisite aidan$ python intersite.py --config config.json --debug verbose
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "intersite.py", line 548, in run
    self.handle_endpoint_event()
  File "intersite.py", line 537, in handle_endpoint_event
    self._endpoints.add_endpoint(ep, self._local_site)
  File "intersite.py", line 239, in add_endpoint
    tenant = app.get_parent()
AttributeError: 'NoneType' object has no attribute 'get_parent'
```
Here is the DN of the object causing the crash:
`uni/ldev-[uni/tn-common/lDevVip-ITSFlow2PAN]-ctx-[uni/tn-common/ctx-none]-bd-[uni/tn-common/BD-Shared.SERVER.Inside.BD]/cep-00:1B:17:00:01:30/ip-[10.208.8.15]
`

Please let me know if you think there is a better solution to this issue.

