### PR TITLE
Fix ContractInterface.get_import_contract() method to match docs

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -3462,9 +3462,9 @@ class ContractInterface(BaseACIObject):
         if not self.has_import_contract():
             return None
         if deleted:
-            return self._get_all_detached_relation(Contract, 'imported')
+            return self._get_all_detached_relation(Contract, 'imported')[0]
         else:
-            return self._get_all_relation(Contract, 'imported')
+            return self._get_all_relation(Contract, 'imported')[0]
 
     def _generate_children(self):
         """

--- a/applications/connection_search/aciConSearch.py
+++ b/applications/connection_search/aciConSearch.py
@@ -1432,7 +1432,7 @@ class SearchDb(object):
                 import_contracts = contract_if.get_import_contract()
 
                 if import_contracts is not None:
-                    consumed_contracts = consumed_contracts | set(import_contracts)
+                    consumed_contracts = consumed_contracts | set([import_contracts])
             provided_contracts = set(epg.get_all_provided())
 
             if isinstance(epg, EPG):


### PR DESCRIPTION
The documentation for the get_import_contract method for the ContractInterface class states that the method returns the imported contract, but it was returning a list containing the contract. Updated the code to match the docs.

Also updated the sample application that uses this method.