### PR TITLE
Updates to make Contract.get_all_consuming/providing_epgs() return all types of EPGs

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -3753,8 +3753,9 @@ class Contract(BaseContract):
             status = 'detached'
         else:
             status = 'attached'
-        for epg in self.get_all_attachments(EPG, status=status, relation_type=relation_type):
-            resp.append(epg)
+        for epg_class in [EPG, AnyEPG, OutsideEPG]:
+            for epg in self.get_all_attachments(epg_class, status=status, relation_type=relation_type):
+                resp.append(epg)
         return resp
 
     def get_all_providing_epgs(self, deleted=False):


### PR DESCRIPTION
Update to address issue #219 
Updated _get_all_epgs() private method (only used by get_all_consuming/providing_epgs() methods to return all types of EPGs, i.e. classes EPG, AnyEPG and OutsideEPG.