### PR TITLE
[intersite] add option to not clean up potentially hanging contracts on first run

### DIFF
--- a/applications/multisite/intersite.py
+++ b/applications/multisite/intersite.py
@@ -460,6 +460,9 @@ class MultisiteMonitor(threading.Thread):
                 logging.error('Could not find remote site %s', site.name)
                 continue
             for l3out in site.get_interfaces():
+                if l3out.noclean:
+                    continue
+
                 itag = IntersiteTag(export_policy.tenant, export_policy.app, export_policy.epg,
                                     self._local_site.name)
 
@@ -811,6 +814,10 @@ class L3OutPolicy(ConfigObject):
     def tenant(self):
         return self._policy['l3out']['tenant']
 
+    @property
+    def noclean(self):
+        return 'noclean' in self._policy['l3out'] and self._policy['l3out']['noclean'] == "True"
+
     def validate(self):
         if 'l3out' not in self._policy:
             raise ValueError('Expecting "l3out" in interface policy')
@@ -822,6 +829,7 @@ class L3OutPolicy(ConfigObject):
                                   'consumes': '_validate_list',
                                   'protected_by': '_validate_list',
                                   'consumes_interface': '_validate_list',
+                                  'noclean': '_validate_boolean_string',
                                   }
             if item not in keyword_validators:
                 raise ValueError(self.__class__.__name__ + 'Unknown keyword: %s' % item)


### PR DESCRIPTION
As it currently stands, when the intersite application does an initialisation (configuration load), it checks the local configuration file's list of contracts and compares it against the live (APIC) view.  If any of the contracts in the APIC view are not defined in the local configuration the intersite application will remove them.

I have a use case where the intersite application isn't the only source of truth for a particular l3out object and would prefer if it only cared about the contracts I have defined.  This PR adds the configuration option `noclean` to the intersite configuration for a specific l3out object which if set to `"True"` will skip the removal of contracts.

If you are okay with the concept of this PR, I will also update the intersite documentation to reflect these changes.