### PR TITLE
Adding hash methods

### DIFF
--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -89,7 +89,7 @@ class BaseRelation(object):
         return NotImplemented
 
     def __hash__(self):
-        return hash(attrgetter('item', 'status', 'relation_type'))
+        return hash((self.item, self.status, self.relation_type))
 
     def __ne__(self, other):
         return not self == other

--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -88,6 +88,9 @@ class BaseRelation(object):
             return key_attrs(self) == key_attrs(other)
         return NotImplemented
 
+    def __hash__(self):
+        return hash(attrgetter('item', 'status', 'relation_type'))
+
     def __ne__(self, other):
         return not self == other
 

--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -986,6 +986,9 @@ class BaseACIObject(AciSearch):
             return self_key == other_key
         return NotImplemented
 
+    def __hash__(self):
+        return hash((self.get_parent(), self.name))
+
     def __ne__(self, other):
         return not self == other
 

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -2924,6 +2924,9 @@ class BaseSubnet(BaseACIObject):
 
         return super(BaseSubnet, self).__eq__(other) and self._addr == other._addr
 
+    def __hash__(self):
+        return BaseACIObject.__hash__(self)
+
 
 class Subnet(BaseSubnet):
     """ Subnet :  roughly equivalent to fvSubnet """

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -4285,6 +4285,18 @@ class FilterEntry(BaseACIObject):
             return key_attrs(self) == key_attrs(other)
         return NotImplemented
 
+    def __hash__(self):
+        return hash((self.applyToFrag,
+                     self.arpOpc,
+                     self.dFromPort,
+                     self.dToPort,
+                     self.etherT,
+                     self.prot,
+                     self.sFromPort,
+                     self.sToPort,
+                     self.tcpRules,
+                     self.stateful))
+
     @staticmethod
     def _get_name_dn_delimiters():
         return ['/e-', '/']

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -4926,7 +4926,5 @@ if __name__ == '__main__':
     # Add tests to this suite while developing the tests
     # This allows only these tests to be run
     develop = unittest.TestSuite()
-    develop.addTest(unittest.makeSuite(TestBaseRelation))
-    develop.addTest(unittest.makeSuite(TestBaseACIObject))
 
     unittest.main(defaultTest='offline')

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -1472,6 +1472,73 @@ class TestFilterEntry(unittest.TestCase):
         self.assertEqual(filt_entry_json['vzEntry']['attributes']['name'],
                          filt_entry_name)
 
+    def test_eq(self):
+        """
+        Test eq method
+        """
+        filt_name = 'filt'
+        filt = Filter(filt_name)
+
+        filt_entry_name = 'FiltEntry'
+        filt_entry = FilterEntry(filt_entry_name, filt)
+
+        filt_entry2_name = 'FiltEntry2'
+        filt_entry2 = FilterEntry(filt_entry2_name, filt)
+        self.assertEqual(filt_entry, filt_entry2)
+
+    def test_hashing_based_on_eq_same_object(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        filt_name = 'filt'
+        filt = Filter(filt_name)
+
+        filt_entry_name = 'FiltEntry'
+        filt_entry = FilterEntry(filt_entry_name, filt)
+
+        filt_entry2_name = 'FiltEntry2'
+        filt_entry2 = FilterEntry(filt_entry2_name, filt)
+        test_dic = {}
+        test_dic[filt_entry] = 5
+        test_dic[filt_entry2] = 10
+        """
+        filt_entry == filt_entry2 in this case as per __eq__, this means that there should
+        only be one entry in the dictonary, otherwise we have duplicated keys.
+        """
+        self.assertEqual(len(test_dic), 1)  
+        self.assertEqual(test_dic[filt_entry], 10)  
+        self.assertEqual(test_dic[filt_entry2], 10)
+
+    def test_hashing_based_on_eq_multiple_objects(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        filt_name = 'filt'
+        filt = Filter(filt_name)
+
+        filt_entry_name = 'FiltEntry'
+        filt_entry = FilterEntry(filt_entry_name, filt)
+
+        filt_entry2_name = 'FiltEntry2'
+        filt_entry2 = FilterEntry(filt_entry2_name, filt)
+
+        filt_entry3_name = 'FiltEntry3'
+        filt_entry3 = FilterEntry(filt_entry3_name, filt)
+        filt_entry3.sFromPort = 80
+
+        self.assertEqual(filt_entry, filt_entry2)
+        self.assertNotEqual(filt_entry, filt_entry3)
+        self.assertNotEqual(filt_entry2, filt_entry3)
+        test_dic = {}
+        test_dic[filt_entry] = 5
+        test_dic[filt_entry2] = 10
+        test_dic[filt_entry3] = 5
+        self.assertEqual(len(test_dic), 2)
+        self.assertEqual(test_dic[filt_entry], 10)
+        self.assertEqual(test_dic[filt_entry2], 10)
+
 
 class TestTaboo(unittest.TestCase):
     """

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -2672,43 +2672,43 @@ class TestPortChannel(unittest.TestCase):
         self.assertFalse(pc.is_vpc())
         fabric, infra = pc.get_json()
 
-        expected_resp = ("{'infraInfra': {'attributes': {}, 'children': [{'infraNodeP': {'attrib"
-                         "utes': {'name': '1-101-1-8'}, 'children': [{'infraLe"
-                         "afS': {'attributes': {'type': 'range', 'name': '1-10"
-                         "1-1-8'}, 'children': [{'infraNodeBlk': {'attributes'"
-                         ": {'from_': '101', 'name': '1-101-1-8', 'to_': '101'"
-                         "}, 'children': []}}]}}, {'infraRsAccPortP': {'attrib"
-                         "utes': {'tDn': 'uni/infra/accportprof-1-101-1-8'}, '"
-                         "children': []}}]}}, {'infraAccPortP': {'attributes':"
-                         " {'name': '1-101-1-8'}, 'children': [{'infraHPortS':"
-                         " {'attributes': {'type': 'range', 'name': '1-101-1-8"
-                         "'}, 'children': [{'infraPortBlk': {'attributes': {'t"
-                         "oPort': '8', 'fromPort': '8', 'fromCard': '1', 'name"
-                         "': '1-101-1-8', 'toCard': '1'}, 'children': []}}, {'"
-                         "infraRsAccBaseGrp': {'attributes': {'tDn': 'uni/infr"
-                         "a/funcprof/accbundle-pc1'}, 'children': []}}]}}]}}, "
-                         "{'infraNodeP': {'attributes': {'name': '1-101-1-9'},"
-                         " 'children': [{'infraLeafS': {'attributes': {'type':"
-                         " 'range', 'name': '1-101-1-9'}, 'children': [{'infra"
-                         "NodeBlk': {'attributes': {'from_': '101', 'name': '1"
-                         "-101-1-9', 'to_': '101'}, 'children': []}}]}}, {'inf"
-                         "raRsAccPortP': {'attributes': {'tDn': 'uni/infra/acc"
-                         "portprof-1-101-1-9'}, 'children': []}}]}}, {'infraAc"
-                         "cPortP': {'attributes': {'name': '1-101-1-9'}, 'chil"
-                         "dren': [{'infraHPortS': {'attributes': {'type': 'ran"
-                         "ge', 'name': '1-101-1-9'}, 'children': [{'infraPortB"
-                         "lk': {'attributes': {'toPort': '9', 'fromPort': '9',"
-                         " 'fromCard': '1', 'name': '1-101-1-9', 'toCard': '1'"
-                         "}, 'children': []}}, {'infraRsAccBaseGrp': {'attribu"
-                         "tes': {'tDn': 'uni/infra/funcprof/accbundle-pc1'}, '"
-                         "children': []}}]}}]}}, {'infraFuncP': {'attributes':"
-                         " {}, 'children': [{'infraAccBndlGrp': {'attributes':"
-                         " {'lagT': 'link', 'name': 'pc1'}, 'children': []}}]}"
-                         "}]}}")
+        expected_resp = json.loads('{"infraInfra": {"attributes": {}, "children": [{"infraNodeP": {"attrib'
+                         'utes": {"name": "1-101-1-8"}, "children": [{"infraLe'
+                         'afS": {"attributes": {"type": "range", "name": "1-10'
+                         '1-1-8"}, "children": [{"infraNodeBlk": {"attributes"'
+                         ': {"from_": "101", "name": "1-101-1-8", "to_": "101"'
+                         '}, "children": []}}]}}, {"infraRsAccPortP": {"attrib'
+                         'utes": {"tDn": "uni/infra/accportprof-1-101-1-8"}, "'
+                         'children": []}}]}}, {"infraAccPortP": {"attributes":'
+                         ' {"name": "1-101-1-8"}, "children": [{"infraHPortS":'
+                         ' {"attributes": {"type": "range", "name": "1-101-1-8'
+                         '"}, "children": [{"infraPortBlk": {"attributes": {"t'
+                         'oPort": "8", "fromPort": "8", "fromCard": "1", "name'
+                         '": "1-101-1-8", "toCard": "1"}, "children": []}}, {"'
+                         'infraRsAccBaseGrp": {"attributes": {"tDn": "uni/infr'
+                         'a/funcprof/accbundle-pc1"}, "children": []}}]}}]}}, '
+                         '{"infraNodeP": {"attributes": {"name": "1-101-1-9"},'
+                         ' "children": [{"infraLeafS": {"attributes": {"type":'
+                         ' "range", "name": "1-101-1-9"}, "children": [{"infra'
+                         'NodeBlk": {"attributes": {"from_": "101", "name": "1'
+                         '-101-1-9", "to_": "101"}, "children": []}}]}}, {"inf'
+                         'raRsAccPortP": {"attributes": {"tDn": "uni/infra/acc'
+                         'portprof-1-101-1-9"}, "children": []}}]}}, {"infraAc'
+                         'cPortP": {"attributes": {"name": "1-101-1-9"}, "chil'
+                         'dren": [{"infraHPortS": {"attributes": {"type": "ran'
+                         'ge", "name": "1-101-1-9"}, "children": [{"infraPortB'
+                         'lk": {"attributes": {"toPort": "9", "fromPort": "9",'
+                         ' "fromCard": "1", "name": "1-101-1-9", "toCard": "1"'
+                         '}, "children": []}}, {"infraRsAccBaseGrp": {"attribu'
+                         'tes": {"tDn": "uni/infra/funcprof/accbundle-pc1"}, "'
+                         'children": []}}]}}]}}, {"infraFuncP": {"attributes":'
+                         ' {}, "children": [{"infraAccBndlGrp": {"attributes":'
+                         ' {"lagT": "link", "name": "pc1"}, "children": []}}]}'
+                         '}]}}')
 
         # TODO: Temporarily disable check in Python3 environments
         if sys.version_info < (3, 0, 0):
-            self.assertEqual(str(infra), str(expected_resp))
+            self.assertEqual(infra, expected_resp)
 
         # Not a VPC, so fabric should be None
         self.assertIsNone(fabric)

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -248,6 +248,40 @@ class TestBaseACIObject(unittest.TestCase):
         obj1.detach(obj2)
         self.assertFalse(obj1.is_attached(obj2))
 
+    def test_hashing_based_on_eq_same_object(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        obj1 = MockACIObject('mock')
+        obj2 = MockACIObject('mock')
+        self.assertTrue(obj1 == obj2)
+        test_dic = {}
+        test_dic[obj1] = 5
+        test_dic[obj2] = 5
+        """
+        obj1 == obj2 in this case as per __eq__, this means that there should
+        only be one entry in the dictonary, otherwise we have duplicated keys.
+        See: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        self.assertEqual(len(test_dic), 1)  
+
+    def test_hashing_based_on_eq_multiple_objects(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        obj1 = MockACIObject('mock')
+        obj2 = MockACIObject('mock')
+        obj3 = MockACIObject('mock2')
+        self.assertTrue(obj1 == obj2)
+        self.assertFalse(obj1 == obj3)
+        self.assertFalse(obj2 == obj3)
+        test_dic = {}
+        test_dic[obj1] = 5
+        test_dic[obj2] = 5
+        test_dic[obj3] = 5
+        self.assertEqual(len(test_dic), 2)
 
 class TestTenant(unittest.TestCase):
     """

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -258,13 +258,15 @@ class TestBaseACIObject(unittest.TestCase):
         self.assertTrue(obj1 == obj2)
         test_dic = {}
         test_dic[obj1] = 5
-        test_dic[obj2] = 5
+        test_dic[obj2] = 10
         """
         obj1 == obj2 in this case as per __eq__, this means that there should
         only be one entry in the dictonary, otherwise we have duplicated keys.
         See: https://github.com/datacenter/acitoolkit/issues/233
         """
         self.assertEqual(len(test_dic), 1)  
+        self.assertEqual(test_dic[obj1], 10)  
+        self.assertEqual(test_dic[obj2], 10)  
 
     def test_hashing_based_on_eq_multiple_objects(self):
         """
@@ -279,9 +281,11 @@ class TestBaseACIObject(unittest.TestCase):
         self.assertFalse(obj2 == obj3)
         test_dic = {}
         test_dic[obj1] = 5
-        test_dic[obj2] = 5
+        test_dic[obj2] = 10
         test_dic[obj3] = 5
         self.assertEqual(len(test_dic), 2)
+        self.assertEqual(test_dic[obj1], 10)
+        self.assertEqual(test_dic[obj2], 10)
 
 class TestTenant(unittest.TestCase):
     """
@@ -4869,5 +4873,7 @@ if __name__ == '__main__':
     # Add tests to this suite while developing the tests
     # This allows only these tests to be run
     develop = unittest.TestSuite()
+    develop.addTest(unittest.makeSuite(TestBaseRelation))
+    develop.addTest(unittest.makeSuite(TestBaseACIObject))
 
-    unittest.main(defaultTest='offline')
+    unittest.main(defaultTest='develop')

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -362,7 +362,7 @@ class TestTenant(unittest.TestCase):
         """
         Ensure class has the correct parent class
         """
-        self.assertEquals(Tenant._get_parent_class(), LogicalModel)
+        self.assertEqual(Tenant._get_parent_class(), LogicalModel)
 
     def test_get_name_from_dn(self):
         """
@@ -426,7 +426,7 @@ class TestAppProfile(unittest.TestCase):
         """
         Test AppProfile._get_parent_class returns Tenant class
         """
-        self.assertEquals(AppProfile._get_parent_class(), Tenant)
+        self.assertEqual(AppProfile._get_parent_class(), Tenant)
 
     def test_get_parent_dn(self):
         """
@@ -434,7 +434,7 @@ class TestAppProfile(unittest.TestCase):
         parent
         """
         dn = 'uni/tn-tenant/ap-test'
-        self.assertEquals(AppProfile._get_parent_dn(dn), 'uni/tn-tenant')
+        self.assertEqual(AppProfile._get_parent_dn(dn), 'uni/tn-tenant')
 
     def test_get_name_from_dn(self):
         """
@@ -442,7 +442,7 @@ class TestAppProfile(unittest.TestCase):
         derived from the dn provided
         """
         dn = 'uni/tn-tenant/ap-test'
-        self.assertEquals(AppProfile._get_name_from_dn(dn), 'test')
+        self.assertEqual(AppProfile._get_name_from_dn(dn), 'test')
 
     def test_delete(self):
         """
@@ -559,7 +559,7 @@ class TestBridgeDomain(unittest.TestCase):
         """
         Test that BridgeDomain._get_parent_class returns Tenant class
         """
-        self.assertEquals(BridgeDomain._get_parent_class(), Tenant)
+        self.assertEqual(BridgeDomain._get_parent_class(), Tenant)
 
     def test_get_parent_dn(self):
         """
@@ -567,7 +567,7 @@ class TestBridgeDomain(unittest.TestCase):
         parent
         """
         dn = 'uni/tn-tenant/BD-test'
-        self.assertEquals(BridgeDomain._get_parent_dn(dn), 'uni/tn-tenant')
+        self.assertEqual(BridgeDomain._get_parent_dn(dn), 'uni/tn-tenant')
 
     def test_get_name_from_dn(self):
         """
@@ -575,7 +575,7 @@ class TestBridgeDomain(unittest.TestCase):
         derived from the dn provided
         """
         dn = 'uni/tn-tenant/BD-test'
-        self.assertEquals(BridgeDomain._get_name_from_dn(dn), 'test')
+        self.assertEqual(BridgeDomain._get_name_from_dn(dn), 'test')
 
     def test_valid_delete(self):
         """
@@ -1245,21 +1245,21 @@ class TestContract(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(Contract._get_parent_class(), Tenant)
+        self.assertEqual(Contract._get_parent_class(), Tenant)
 
     def test_get_parent_dn(self):
         """
         Test _get_parent_dn method
         """
         dn = 'uni/tn-tenant/brc-test'
-        self.assertEquals(Contract._get_parent_dn(dn), 'uni/tn-tenant')
+        self.assertEqual(Contract._get_parent_dn(dn), 'uni/tn-tenant')
 
     def test_get_name_from_dn(self):
         """
         Test getting the contract name from _get_parent_dn method
         """
         dn = 'uni/tn-tenant/brc-test'
-        self.assertEquals(Contract._get_name_from_dn(dn), 'test')
+        self.assertEqual(Contract._get_name_from_dn(dn), 'test')
 
     def test_internal_generate_attributes(self):
         """
@@ -1287,7 +1287,7 @@ class TestContractSubject(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(ContractSubject._get_parent_class(), [Contract, Taboo])
+        self.assertEqual(ContractSubject._get_parent_class(), [Contract, Taboo])
 
     def test_get_json(self):
         """
@@ -1343,7 +1343,7 @@ class TestInputTerminal(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(InputTerminal._get_parent_class(), ContractSubject)
+        self.assertEqual(InputTerminal._get_parent_class(), ContractSubject)
 
     def test_get_json(self):
         """
@@ -1385,7 +1385,7 @@ class TestOutputTerminal(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(OutputTerminal._get_parent_class(), ContractSubject)
+        self.assertEqual(OutputTerminal._get_parent_class(), ContractSubject)
 
     def test_get_json(self):
         """
@@ -1509,21 +1509,21 @@ class TestTaboo(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(Taboo._get_parent_class(), Tenant)
+        self.assertEqual(Taboo._get_parent_class(), Tenant)
 
     def test_get_parent_dn(self):
         """
         Test _get_parent_dn method
         """
         dn = 'uni/tn-tenant/taboo-test'
-        self.assertEquals(Taboo._get_parent_dn(dn), 'uni/tn-tenant')
+        self.assertEqual(Taboo._get_parent_dn(dn), 'uni/tn-tenant')
 
     def test_get_name_from_dn(self):
         """
         Test _get_name_from_dn method
         """
         dn = 'uni/tn-tenant/taboo-test'
-        self.assertEquals(Taboo._get_name_from_dn(dn), 'test')
+        self.assertEqual(Taboo._get_name_from_dn(dn), 'test')
 
     def test_get_table(self):
         """
@@ -1581,21 +1581,21 @@ class TestEPG(unittest.TestCase):
         """
         Test EPG parent class is AppProfile
         """
-        self.assertEquals(EPG._get_parent_class(), AppProfile)
+        self.assertEqual(EPG._get_parent_class(), AppProfile)
 
     def test_get_parent_dn(self):
         """
         Test _get_parent_dn method
         """
         dn = 'uni/tn-tenant/ap-app/epg-test'
-        self.assertEquals(EPG._get_parent_dn(dn), 'uni/tn-tenant/ap-app')
+        self.assertEqual(EPG._get_parent_dn(dn), 'uni/tn-tenant/ap-app')
 
     def test_get_name_from_dn(self):
         """
         Test _get_name_from_dn method
         """
         dn = 'uni/tn-tenant/ap-app/epg-test'
-        self.assertEquals(EPG._get_name_from_dn(dn), 'test')
+        self.assertEqual(EPG._get_name_from_dn(dn), 'test')
 
     def test_valid_add_bd(self):
         """
@@ -1914,7 +1914,7 @@ class TestEPG(unittest.TestCase):
         epg.protect(taboo)
         output = tenant.get_json()
         self.assertIn('fvRsProtBy', str(output))
-        self.assertEquals(str(output).count('fvRsProtBy'), 1)
+        self.assertEqual(str(output).count('fvRsProtBy'), 1)
 
     def test_does_protect(self):
         """
@@ -2820,21 +2820,21 @@ class TestContext(unittest.TestCase):
         """
         Test _get_parent_class method
         """
-        self.assertEquals(Context._get_parent_class(), Tenant)
+        self.assertEqual(Context._get_parent_class(), Tenant)
 
     def test_get_parent_dn(self):
         """
         Test _get_parent_dn method
         """
         dn = 'uni/tn-tenant/ctx-test'
-        self.assertEquals(Context._get_parent_dn(dn), 'uni/tn-tenant')
+        self.assertEqual(Context._get_parent_dn(dn), 'uni/tn-tenant')
 
     def test_get_name_from_dn(self):
         """
         Test _get_name_from_dn method
         """
         dn = 'uni/tn-tenant/ctx-test'
-        self.assertEquals(Context._get_name_from_dn(dn), 'test')
+        self.assertEqual(Context._get_name_from_dn(dn), 'test')
 
     def test_set_allow_all(self):
         """
@@ -3017,7 +3017,7 @@ class TestLiveTenant(TestLiveAPIC):
         for tenant in tenants:
             self.assertTrue(isinstance(tenant, Tenant))
             self.assertTrue(isinstance(tenant.name, str))
-            self.assertEquals(tenant.get_parent(), logical_model)
+            self.assertEqual(tenant.get_parent(), logical_model)
 
     def test_get_deep_tenants(self):
         """
@@ -3994,7 +3994,7 @@ class TestLivePhysDomain(TestLiveAPIC):
 
         # Test get by name function (passing conditional to successfully find name)
         phys_domain_by_name = PhysDomain.get_by_name(session, 'phys_domain_toolkit_test')
-        self.assertEquals(phys_domain_by_name, new_phys_domain)
+        self.assertEqual(phys_domain_by_name, new_phys_domain)
 
         # Delete new phys domain
         new_phys_domain.mark_as_deleted()
@@ -4929,4 +4929,4 @@ if __name__ == '__main__':
     develop.addTest(unittest.makeSuite(TestBaseRelation))
     develop.addTest(unittest.makeSuite(TestBaseACIObject))
 
-    unittest.main(defaultTest='develop')
+    unittest.main(defaultTest='offline')

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -152,6 +152,52 @@ class TestBaseRelation(unittest.TestCase):
         self.assertFalse(relation.is_attached())
         self.assertTrue(relation.is_detached())
 
+    def test_eq(self):
+        """
+        Test __eq__
+        """
+        tenant, relation = self.create_attached_relation()
+        tenant2, relation2 = self.create_attached_relation()
+        self.assertEqual(relation, relation2)
+
+    def test_hashing_based_on_eq_same_object(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        tenant, relation = self.create_attached_relation()
+        tenant2, relation2 = self.create_attached_relation()
+        test_dic = {}
+        test_dic[relation] = 5
+        test_dic[relation2] = 10
+        """
+        obj1 == obj2 in this case as per __eq__, this means that there should
+        only be one entry in the dictonary, otherwise we have duplicated keys.
+        See: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        self.assertEqual(len(test_dic), 1)  
+        self.assertEqual(test_dic[relation], 10)  
+        self.assertEqual(test_dic[relation2], 10)  
+
+    def test_hashing_based_on_eq_multiple_objects(self):
+        """
+        Test that the __hash__ works according to __eq__
+        Details: https://github.com/datacenter/acitoolkit/issues/233
+        """
+        tenant, relation = self.create_attached_relation()
+        tenant2, relation2 = self.create_attached_relation()
+        tenant3, relation3 = self.create_detached_relation()
+        self.assertEqual(relation, relation2)
+        self.assertNotEqual(relation, relation3)
+        self.assertNotEqual(relation2, relation3)
+        test_dic = {}
+        test_dic[relation] = 5
+        test_dic[relation2] = 10
+        test_dic[relation3] = 5
+        self.assertEqual(len(test_dic), 2)
+        self.assertEqual(test_dic[relation], 10)
+        self.assertEqual(test_dic[relation2], 10)
+
 
 class MockACIObject(BaseACIObject):
     """
@@ -248,6 +294,14 @@ class TestBaseACIObject(unittest.TestCase):
         obj1.detach(obj2)
         self.assertFalse(obj1.is_attached(obj2))
 
+    def test_eq(self):
+        """
+        Test __eq__
+        """
+        obj1 = MockACIObject('mock')
+        obj2 = MockACIObject('mock')
+        self.assertEqual(obj1, obj2)
+
     def test_hashing_based_on_eq_same_object(self):
         """
         Test that the __hash__ works according to __eq__
@@ -255,7 +309,6 @@ class TestBaseACIObject(unittest.TestCase):
         """
         obj1 = MockACIObject('mock')
         obj2 = MockACIObject('mock')
-        self.assertTrue(obj1 == obj2)
         test_dic = {}
         test_dic[obj1] = 5
         test_dic[obj2] = 10
@@ -276,9 +329,9 @@ class TestBaseACIObject(unittest.TestCase):
         obj1 = MockACIObject('mock')
         obj2 = MockACIObject('mock')
         obj3 = MockACIObject('mock2')
-        self.assertTrue(obj1 == obj2)
-        self.assertFalse(obj1 == obj3)
-        self.assertFalse(obj2 == obj3)
+        self.assertEqual(obj1, obj2)
+        self.assertNotEqual(obj1, obj3)
+        self.assertNotEqual(obj2, obj3)
         test_dic = {}
         test_dic[obj1] = 5
         test_dic[obj2] = 10

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -171,9 +171,8 @@ class TestBaseRelation(unittest.TestCase):
         test_dic[relation] = 5
         test_dic[relation2] = 10
         """
-        obj1 == obj2 in this case as per __eq__, this means that there should
+        relation == relation2 in this case as per __eq__, this means that there should
         only be one entry in the dictonary, otherwise we have duplicated keys.
-        See: https://github.com/datacenter/acitoolkit/issues/233
         """
         self.assertEqual(len(test_dic), 1)  
         self.assertEqual(test_dic[relation], 10)  
@@ -315,7 +314,6 @@ class TestBaseACIObject(unittest.TestCase):
         """
         obj1 == obj2 in this case as per __eq__, this means that there should
         only be one entry in the dictonary, otherwise we have duplicated keys.
-        See: https://github.com/datacenter/acitoolkit/issues/233
         """
         self.assertEqual(len(test_dic), 1)  
         self.assertEqual(test_dic[obj1], 10)  


### PR DESCRIPTION
I implemented the required `__hash__` methods, there are more Classes with `__eq__` but i think these don't require hashing. But i will double check that.

Python3 passes now all offline tests.
But there is still a issue with the websocket of the Subscriber class, there is a segmentation error on the `self._ws.close()` call.

I also swapped the `assertEquals` with `assertEqual`, these are synonyms, but python3 generates a deprecated warning for [`assertEquals`](https://docs.python.org/3.5/library/unittest.html#deprecated-aliases)

---
Related:
#230 #233 