### PR TITLE
Adjust defaults for 'timestop' and search query.

### DIFF
--- a/applications/endpointtracker/aci-endpoint-tracker.py
+++ b/applications/endpointtracker/aci-endpoint-tracker.py
@@ -98,7 +98,7 @@ def connect_mysql(args):
                          epg       CHAR(100) NOT NULL,
                          interface CHAR(100) NOT NULL,
                          timestart TIMESTAMP NOT NULL,
-                         timestop  TIMESTAMP);''')
+                         timestop  TIMESTAMP NULL);''')
         cnx.commit()
 
     return c, cnx
@@ -148,7 +148,7 @@ def tracker(args):
         ep_exists = c.execute("""SELECT * FROM endpoints
                                  WHERE mac="%s"
                                  AND
-                                 timestop="0000-00-00 00:00:00";""" % ep.mac)
+                                 timestop is null;""" % ep.mac)
         c.fetchall()
         if not ep_exists:
             c.execute("""INSERT INTO endpoints (mac, ip, tenant,
@@ -177,7 +177,7 @@ def tracker(args):
                 update_cmd = """UPDATE endpoints SET timestop='%s',
                                 timestart=timestart
                                 WHERE mac='%s' AND tenant='%s' AND
-                                timestop='0000-00-00 00:00:00'""" % data
+                                timestop is null""" % data
                 c.execute(update_cmd)
             else:
                 if ep.if_dn:


### PR DESCRIPTION
I encountered errors with endpointtracker deploying tables to a new DB, which results from an error: 

> Traceback (most recent call last):
>   File "./aci-endpoint-tracker.py", line 276, in <module>
>     main()
>   File "./aci-endpoint-tracker.py", line 272, in main
>     tracker(args)
>   File "./aci-endpoint-tracker.py", line 120, in tracker
>     c, cnx = connect_mysql(args)
>   File "./aci-endpoint-tracker.py", line 101, in connect_mysql
>     timestop  TIMESTAMP);''')
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/cursors.py", line 166, in execute
>     result = self._query(query)
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/cursors.py", line 322, in _query
>     conn.query(q)
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/connections.py", line 835, in query
>     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/connections.py", line 1019, in _read_query_result
>     result.read()
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/connections.py", line 1302, in read
>     first_packet = self.connection._read_packet()
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/connections.py", line 981, in _read_packet
>     packet.check_error()
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/connections.py", line 393, in check_error
>     err.raise_mysql_exception(self._data)
>   File "/usr/local/lib/python2.7/dist-packages/PyMySQL-0.7.9-py2.7.egg/pymysql/err.py", line 107, in raise_mysql_exception
>     raise errorclass(errno, errval)
> pymysql.err.InternalError: (1067, u"Invalid default value for 'timestop'")
> 

The value of '0000-00-00 00:00:00' is not according to MySQL docs a valid range of timestamps, but is considered the "zero" value when an invalid value type tries to be converted to timestamp.

As seen by issue #196 under a new deployment the database table fails to create. After looking over the code it seems like the value of '0000-00-00 00:00:00' is used like a null type.

This fix changes the default for timestop to use null and then the queries to look for 'is null' instead. This allows the table to create and function as expected.

No changes to the gui were needed as it already looks for records with "None" or null and converts them in display to  '0000-00-00 00:00:00'.

I'm up for doing this different, this way just seems to work from what I can tell in the code.