### PR TITLE
Add certificate based authentication to Session class

### DIFF
--- a/acitoolkit/acitoolkitlib.py
+++ b/acitoolkit/acitoolkitlib.py
@@ -88,6 +88,8 @@ class Credentials(object):
             DEFAULT_URL = set_default('url')
             DEFAULT_LOGIN = set_default('login')
             DEFAULT_PASSWORD = set_default('password')
+            DEFAULT_CERT_NAME = set_default('cert_name')
+            DEFAULT_KEY = set_default('key')
             self._parser.add_argument('-u', '--url',
                                       default=DEFAULT_URL,
                                       help='APIC URL e.g. http://1.2.3.4')
@@ -97,6 +99,12 @@ class Credentials(object):
             self._parser.add_argument('-p', '--password',
                                       default=DEFAULT_PASSWORD,
                                       help='APIC login password.')
+            self._parser.add_argument('-c', '--cert-name',
+                                      default=DEFAULT_CERT_NAME,
+                                      help='X.509 certificate name attached to APIC AAA user')
+            self._parser.add_argument('-k', '--key',
+                                      default=DEFAULT_KEY,
+                                      help='Private key matching given certificate, used to generate authentication signature')
         if 'nosnapshotfiles' not in qualifier and 'apic' in qualifier:
             self._parser.add_argument('--snapshotfiles', nargs='+',
                                       help='APIC configuration files')
@@ -212,8 +220,15 @@ class Credentials(object):
                 self._args.login = self._get_from_user('APIC login username: ')
             if self._args.url is None:
                 self._args.url = self._get_from_user('APIC URL: ')
-            if self._args.password is None:
+
+            if self._args.password is None and not (self._args.cert_name or self._args.key):
                 self._args.password = self._get_password('APIC Password: ')
+            else:
+                if self._args.cert_name is None:
+                    self._args.cert_name = self._get_from_user('Certificate Name: ')
+                if self._args.key is None:
+                    self._args.key = self._get_from_user('Private Key: ')
+
         if 'mysql' in self._qualifier:
             if self._args.mysqlip is None:
                 self._args.mysqlip = self._get_from_user('MySQL IP address: ')

--- a/docs/source/tutorialsimpleconfig.rst
+++ b/docs/source/tutorialsimpleconfig.rst
@@ -255,6 +255,52 @@ call was successful.
    if resp.ok:
       print 'Success'
 
+`APIC Login (Certificate based)`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The APIC REST API also supports authentication using certificates.
+
+Once setup, it is a more simple and secure form of authentication, with each request being
+uniquely signed. Additionally, login timeout issues are removed. An important point to note
+is that websockets (events) are not supported by the APIC when using certficate authentication,
+so the corresponding acitoolkit functionality will be disabled.
+
+As a prerequisite you must have created a private key and public certificate and attached the
+certificate to the desired user using the APIC Web UI.
+
+Creating a certificate session using the acitoolkit is simple:
+
+1. Use OpenSSL to generate a X.509 certificate and private key. 
+
+.. code-block:: bash
+
+   openssl req -new -newkey rsa:1024 -days 36500 -nodes -x509 -keyout userabc.key -out userabc.crt -subj '/CN=User ABC/O=Cisco Systems/C=US'
+
+2. Upload the generated certificate ``userabc.crt`` to the user via the APIC 
+
+.. image:: userabc.crt.png
+
+3. Certificate authentication has an extra dependency, not installed by default, which can be easily
+installed using pip
+
+.. code-block:: bash
+
+   pip install pyopenssl
+
+4. Create a certificate based authentication session
+
+.. code-block:: python
+
+   # Generic
+   session = Session(URL, LOGIN, cert_name=CERT_NAME, key=KEY)
+
+   # Example
+   session = Session('https://1.1.1.1', 'userabc', cert_name='userabc.crt', key='userabc.key')
+
+You do not need to explicitly call the ``login()`` method when using certificate authentication.
+
+After this point, you can continue to use all of the acitoolkit methods to get and push configuration from the APIC securely and without logging in.
+
 Displaying the JSON Configuration
 ---------------------------------
 

--- a/tests/acitoolkit_test.py
+++ b/tests/acitoolkit_test.py
@@ -48,7 +48,7 @@ import json
 import sys
 
 try:
-    from credentials import URL, LOGIN, PASSWORD
+    from credentials import URL, LOGIN, PASSWORD, CERT_NAME, KEY
 except ImportError:
     print
     print('To run live tests, please create a credentials.py file with the following variables filled in:')
@@ -56,6 +56,8 @@ except ImportError:
     URL = ''
     LOGIN = ''
     PASSWORD = ''
+    CERT_NAME = ''
+    KEY = ''
     """)
 
 MAX_RANDOM_STRING_SIZE = 20
@@ -3186,6 +3188,16 @@ class TestLiveAPIC(unittest.TestCase):
         return session
 
 
+class TestLiveCertAuth(TestLiveAPIC):
+    """
+    Certificate auth tests with a live APIC
+    """
+    def test_login_to_apic_with_cert(self):
+        session = Session(URL, LOGIN, cert_name=CERT_NAME, key=KEY)
+        tenants = Tenant.get(session)
+        self.assertTrue(len(tenants) > 0)
+
+
 class TestLiveTenant(TestLiveAPIC):
     """
     Tenant tests on a live APIC
@@ -5252,6 +5264,7 @@ if __name__ == '__main__':
     live.addTest(unittest.makeSuite(TestLiveHealthScores))
     live.addTest(unittest.makeSuite(TestLiveTenant))
     live.addTest(unittest.makeSuite(TestLiveAPIC))
+    live.addTest(unittest.makeSuite(TestLiveCertAuth))
     live.addTest(unittest.makeSuite(TestLiveInterface))
     live.addTest(unittest.makeSuite(TestLivePortChannel))
     live.addTest(unittest.makeSuite(TestLiveAppProfile))


### PR DESCRIPTION
Code:
  - Requires pyopenssl module as a new - optional - dependency
  - Add two new parameters to the session class cert_name and key
  - Checks for presence of password or cert details
  - Disables subscription if using certs (API does not support)
  - Generates a unique signature for each GET or POST request
  - Short circuits login retries if using cert auth

Misc:
  - Extend library argparser to support cert parameters
  - Add certificate login live test
  - Update documentation with certificate auth example

This fixes #186 "Certificate based authentication"

One point of discussion would be adding a significant dependency: `pyopenssl`. With newer versions of pip it is a breeze to install (it will pick pre-built wheels automatically). Older versions of pip will require local compilation which could make installing acitoolkit harder in some environments. 

I have made it an optional dependency by only requiring installation at runtime when the user selects certificate auth, gracefully letting them know if it is not available and how they can install it. This allows the majority of acitoolkit users to not have to worry about how they will install `pyopenssl`