### PR TITLE
Added Python3.5 to shippable, Updated Tests

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "pypy"
 cache: true
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.4"
   - "pypy"
 cache: true
 

--- a/tests/aciphysobject_test.py
+++ b/tests/aciphysobject_test.py
@@ -618,16 +618,16 @@ class TestCluster(unittest.TestCase):
     def test_get_config_size(self):
         cluster = Cluster('test-cluster')
         cluster.config_size = 50
-        self.assertEquals(cluster.get_config_size(), 50)
+        self.assertEqual(cluster.get_config_size(), 50)
 
     def test_get_cluster_size(self):
         cluster = Cluster('test-cluster')
         cluster.cluster_size = 50
-        self.assertEquals(cluster.get_cluster_size(), 50)
+        self.assertEqual(cluster.get_cluster_size(), 50)
 
     def test_get_apics(self):
         cluster = Cluster('test-cluster')
-        self.assertEquals(len(cluster.get_apics()), 0)
+        self.assertEqual(len(cluster.get_apics()), 0)
 
 
 class TestLiveAPIC(unittest.TestCase):


### PR DESCRIPTION
- Shippable is now run against Python3.5
- Updates some tests that used assertEquals to use the newer assertEqual