### PR TITLE
add subscription support for appcenter_user with cert authentication

### DIFF
--- a/acitoolkit/acisession.py
+++ b/acitoolkit/acisession.py
@@ -500,7 +500,7 @@ class Session(object):
 
             self.cert_auth = True
             # Cert based auth does not support subscriptions :(  
-            # exception for appcenter_user
+            # there's an exception for appcenter_user relying on the requestAppToken api
             if subscription_enabled and not self.appcenter_user:
                 logging.warning('Disabling subscription support as certificate authentication does not support it.')
                 logging.warning('Consider passing subscription_enabled=False to hide this warning message.')
@@ -560,7 +560,8 @@ class Session(object):
         if not self.cert_auth:
             return {}
 
-        # for appcenter_user with subscription enabled and correctly logged, skip?
+        # for appcenter_user with subscription enabled and currently logged_in
+        # no need to build x509 header since authentication is using token
         if self.appcenter_user and self._subscription_enabled and self._logged_in:
             return {}
 

--- a/docs/source/tutorialsimpleconfig.rst
+++ b/docs/source/tutorialsimpleconfig.rst
@@ -300,10 +300,14 @@ installed using pip
 
 .. note:: If using the acitoolkit from the context of an APIC App Center app, make sure to pass the extra
    parameter ``appcenter_user=True``. App Center apps are provided a user that belongs to a different class
-   of users.
+   of users.  The login and cert_name for App Center users are both in the form of ``vendor_appId``.  
+   App Center users support certificate subsciptions through a special requestAppToken api. To use 
+   subscriptions with an App Center user, you must explicitly call the ``login()`` method which acquires
+   and maintains the App user token. Disable App center subscriptions by setting the parameter 
+   ``subscription_enabled=False``.
 
 
-You do not need to explicitly call the ``login()`` method when using certificate authentication.
+You do not need to explicitly call the ``login()`` method when using certificate authentication.  
 
 After this point, you can continue to use all of the acitoolkit methods to get and push configuration from the APIC securely and without logging in.
 


### PR DESCRIPTION
appcenter supports subscription with certificate based authentication only for appcenter_user (for now).  This is via the new /api/requestAppToken which uses certificate to acquire a token and then normal aaaRefresh/subscriptionRefresh to maintain token and subscriptions.  All future queries can be performed with a valid token.