### PR TITLE
fix graphviz requirements in docker images for aci-diagram to address issue #282

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu
 MAINTAINER Kevin Corbin, kecorbin@cisco.com
 RUN apt-get update
 RUN apt-get -y install git python python-pip 
+RUN apt-get -y install graphviz graphviz-dev pkg-config
 WORKDIR /opt
 RUN git clone https://github.com/datacenter/acitoolkit
 WORKDIR acitoolkit

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
                       "py-radix",
                       "jsonschema",
                       "graphviz",
+                      "pygraphviz",
                       "ipaddress",
                       "deepdiff"],
     tests_requires=["mock"],


### PR DESCRIPTION
Update Dockerfile and setup.py to install graphviz libraries and pygraphviz module to support aci-diagram. 