### PR TITLE
Add json output option

### DIFF
--- a/samples/aci-create-bd.py
+++ b/samples/aci-create-bd.py
@@ -17,6 +17,7 @@ def main():
     creds.add_argument('--bd', help='The name of BridgeDomain')
     creds.add_argument('--address', help='Subnet IPv4 Address')
     creds.add_argument('--scope', help='The scope of subnet ("public", "private", "shared", "public,shared", "private,shared", "shared,public", "shared,private")')
+    creds.add_argument('--json', const='false', nargs='?', help='Json output only')
 
     args = creds.get()
     session = Session(args.url, args.login, args.password)
@@ -42,12 +43,15 @@ def main():
         else:
             subnet.set_scope(args.scope)
 
-    resp = session.push_to_apic(tenant.get_url(),
-                                tenant.get_json())
-
-    if not resp.ok:
-        print('%% Error: Could not push configuration to APIC')
-        print(resp.text)
+    if args.json:
+        print(tenant.get_json())
+    else:
+        resp = session.push_to_apic(tenant.get_url(),
+                                    tenant.get_json())
+    
+        if not resp.ok:
+            print('%% Error: Could not push configuration to APIC')
+            print(resp.text)
 
 if __name__ == '__main__':
     main()

--- a/samples/aci-create-epg.py
+++ b/samples/aci-create-epg.py
@@ -16,6 +16,7 @@ def main():
     creds.add_argument('--app', help='The name of ApplicationProfile')
     creds.add_argument('--bd', help='The name of BridgeDomain')
     creds.add_argument('--epg', help='The name of EPG')
+    creds.add_argument('--json', const='false', nargs='?', help='Json output only')
 
     args = creds.get()
     session = Session(args.url, args.login, args.password)
@@ -27,13 +28,15 @@ def main():
     epg = EPG(args.epg, app)
     epg.add_bd(bd)
 
-    resp = session.push_to_apic(tenant.get_url(),
-                                tenant.get_json())
-
-    if not resp.ok:
-        print('%% Error: Could not push configuration to APIC')
-        print(resp.text)
+    if args.json:
+        print(tenant.get_json())
+    else:
+        resp = session.push_to_apic(tenant.get_url(),
+                                    tenant.get_json())
+    
+        if not resp.ok:
+            print('%% Error: Could not push configuration to APIC')
+            print(resp.text)        
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
- Add 'json output only' option to:
    - samples/aci-create-bd.py
    - samples/aci-create-epg.py
- I tested it in the following environment.
    - [Python 2.7.13](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-2.7.13)
    - [Python 3.5.3](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-3.5.3)
    - [Python 3.6.1](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-3.6.1)

# Examples

## aci-create-bd.py

```
# ./aci-create-bd.py --tenant Tenant-A --vrf Vrf-A --bd Bd-A --address 192.168.1.1/24 --scope private --json
{'fvTenant': {'attributes': {'name': 'Tenant-A'}, 'children': [{'fvBD': {'attributes': {'name': 'Bd-A', 'unkMacUcastAct': 'proxy', 'arpFlood': 'no', 'multiDstPktAct': 'bd-flood', 'unicastRoute': 'yes', 'unkMcastAct': 'flood'}, 'children': [{'fvRsCtx': {'attributes': {'tnFvCtxName': 'Vrf-A'}}}, {'fvSubnet': {'attributes': {'ip': '192.168.1.1/24', 'name': '', 'scope': 'private'}, 'children': []}}]}}]}}
```

## aci-create-epg.py

```sh
# ./aci-create-epg.py --tenant Tenant-A --app AppProf-A --bd Bd-A --json --epg Epg-A
{'fvTenant': {'attributes': {'name': 'Tenant-A'}, 'children': [{'fvAp': {'attributes': {'name': 'AppProf-A'}, 'children': [{'fvAEPg': {'attributes': {'name': 'Epg-A'}, 'children': [{'fvRsBd': {'attributes': {'tnFvBDName': 'Bd-A'}}}]}}]}}, {'fvBD': {'attributes': {'name': 'Bd-A', 'unkMacUcastAct': 'proxy', 'unkMcastAct': 'flood', 'arpFlood': 'no', 'unicastRoute': 'yes', 'multiDstPktAct': 'bd-flood'}, 'children': []}}]}}
```
