### PR TITLE
Add option to speficy tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ Required
 
 ## Downloading
 
-Option A:
+### Option A:
 
 If you have git installed, clone the repository
 
     git clone https://github.com/datacenter/acitoolkit.git
 
-Option B:
+### Option B:
 
 If you don't have git, [download a zip copy of the repository](https://github.com/datacenter/acitoolkit/archive/master.zip) and extract.
 
-Option C:
+### Option C:
 
 The latest build of this project is also available as a Docker image from Docker Hub
 

--- a/samples/aci-show-cdp.py
+++ b/samples/aci-show-cdp.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Simple application that logs on to the APIC, pull all CDP neighbours,
 and display in text table format
@@ -6,7 +8,6 @@ import acitoolkit.acitoolkit as ACI
 from acitoolkit import Node
 from acitoolkit.aciConcreteLib import ConcreteCdp
 from tabulate import tabulate
-
 
 def main():
     """

--- a/samples/aci-show-contexts.py
+++ b/samples/aci-show-contexts.py
@@ -1,33 +1,5 @@
 #!/usr/bin/env python
-################################################################################
-#                 _    ____ ___   _____           _ _    _ _                   #
-#                / \  / ___|_ _| |_   _|__   ___ | | | _(_) |_                 #
-#               / _ \| |    | |    | |/ _ \ / _ \| | |/ / | __|                #
-#              / ___ \ |___ | |    | | (_) | (_) | |   <| | |_                 #
-#        ____ /_/   \_\____|___|___|_|\___/ \___/|_|_|\_\_|\__|                #
-#       / ___|___   __| | ___  / ___|  __ _ _ __ ___  _ __ | | ___  ___        #
-#      | |   / _ \ / _` |/ _ \ \___ \ / _` | '_ ` _ \| '_ \| |/ _ \/ __|       #
-#      | |__| (_) | (_| |  __/  ___) | (_| | | | | | | |_) | |  __/\__ \       #
-#       \____\___/ \__,_|\___| |____/ \__,_|_| |_| |_| .__/|_|\___||___/       #
-#                                                    |_|                       #
-################################################################################
-#                                                                              #
-# Copyright (c) 2015 Cisco Systems                                             #
-# All Rights Reserved.                                                         #
-#                                                                              #
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may   #
-#    not use this file except in compliance with the License. You may obtain   #
-#    a copy of the License at                                                  #
-#                                                                              #
-#         http://www.apache.org/licenses/LICENSE-2.0                           #
-#                                                                              #
-#    Unless required by applicable law or agreed to in writing, software       #
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT #
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the  #
-#    License for the specific language governing permissions and limitations   #
-#    under the License.                                                        #
-#                                                                              #
-################################################################################
+
 """
 Simple application that logs on to the APIC and displays all
 of the Contexts.
@@ -35,7 +7,9 @@ of the Contexts.
 import sys
 import acitoolkit.acitoolkit as ACI
 
-
+data = []
+longest_names = {'Tenant': len('Tenant'),
+                 'Context': len('Context')}
 def main():
     """
     Main execution routine
@@ -46,6 +20,7 @@ def main():
     # Otherwise, take them from your environment variables file ~/.profile
     description = 'Simple application that logs on to the APIC and displays all of the Contexts.'
     creds = ACI.Credentials('apic', description)
+    creds.add_argument('--tenant', help='The name of Tenant')
     args = creds.get()
 
     # Login to APIC
@@ -57,21 +32,35 @@ def main():
 
     # Download all of the contexts
     # and store the data as tuples in a list
-    data = []
     tenants = ACI.Tenant.get(session)
     for tenant in tenants:
-        contexts = ACI.Context.get(session, tenant)
-        for context in contexts:
-            data.append((tenant.name, context.name))
+        check_longest_name(tenant.name, "Tenant")
+        if args.tenant is None:
+            get_context(session, tenant)
+        else:
+            if tenant.name == args.tenant:
+                get_context(session, tenant)
 
     # IPython.embed()
 
     # Display the data downloaded
-    template = '{0:19} {1:20}'
+    template = '{0:' + str(longest_names["Tenant"]) + '} ' \
+               '{1:' + str(longest_names["Context"]) + '}'
     print(template.format("Tenant", "Context"))
-    print(template.format("------", "-------"))
-    for rec in data:
+    print(template.format('-' * longest_names["Tenant"],
+                          '-' * longest_names["Context"]))
+    for rec in sorted(data):
         print(template.format(*rec))
+
+def get_context(session, tenant):
+    contexts = ACI.Context.get(session, tenant)
+    for context in contexts:
+        check_longest_name(context.name, "Context")
+        data.append((tenant.name, context.name))
+
+def check_longest_name(item, title):
+    if len(item) > longest_names[title]:
+        longest_names[title] = len(item)
 
 if __name__ == '__main__':
     main()

--- a/samples/aci-show-domains.py
+++ b/samples/aci-show-domains.py
@@ -1,40 +1,11 @@
 #!/usr/bin/env python
-################################################################################
-#                 _    ____ ___   _____           _ _    _ _                   #
-#                / \  / ___|_ _| |_   _|__   ___ | | | _(_) |_                 #
-#               / _ \| |    | |    | |/ _ \ / _ \| | |/ / | __|                #
-#              / ___ \ |___ | |    | | (_) | (_) | |   <| | |_                 #
-#        ____ /_/   \_\____|___|___|_|\___/ \___/|_|_|\_\_|\__|                #
-#       / ___|___   __| | ___  / ___|  __ _ _ __ ___  _ __ | | ___  ___        #
-#      | |   / _ \ / _` |/ _ \ \___ \ / _` | '_ ` _ \| '_ \| |/ _ \/ __|       #
-#      | |__| (_) | (_| |  __/  ___) | (_| | | | | | | |_) | |  __/\__ \       #
-#       \____\___/ \__,_|\___| |____/ \__,_|_| |_| |_| .__/|_|\___||___/       #
-#                                                    |_|                       #
-################################################################################
-#                                                                              #
-# Copyright (c) 2015 Cisco Systems                                             #
-# All Rights Reserved.                                                         #
-#                                                                              #
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may   #
-#    not use this file except in compliance with the License. You may obtain   #
-#    a copy of the License at                                                  #
-#                                                                              #
-#         http://www.apache.org/licenses/LICENSE-2.0                           #
-#                                                                              #
-#    Unless required by applicable law or agreed to in writing, software       #
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT #
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the  #
-#    License for the specific language governing permissions and limitations   #
-#    under the License.                                                        #
-#                                                                              #
-################################################################################
+
 """
 Simple application that logs on to the APIC and displays all
 of the Physical Domains, VMM Domains, and EPG associations.
 """
 import sys
 import acitoolkit.acitoolkit as aci
-
 
 def main():
     """
@@ -118,7 +89,7 @@ def main():
     if len(domains) > 0:
         template = '{0:20} {1:11} {2:26}'
         print (template.format('Infra Domain Profile', 'Domain Type', 'TENANT:APP:EPG Association'))
-        print (template.format('--------------------', '-----------', '--------------------------'))
+        print(template.format("-" * 20, "-" * 11, "-" * 26))
         for rec in output:
             print (template.format(*rec))
         print ('\n')

--- a/samples/aci-show-imported-contracts.py
+++ b/samples/aci-show-imported-contracts.py
@@ -1,11 +1,13 @@
+#!/usr/bin/env python
+
 """
 Find out where a contract has been imported and consumed on an EPG.
-
 """
 import acitoolkit.acitoolkit as aci
 from acitoolkit.acitoolkit import *
 from tabulate import tabulate
 
+data = []
 
 def main():
     description = ('Simple application that logs on to the APIC'
@@ -23,7 +25,6 @@ def main():
     if not resp.ok:
         print('%% Could not login to APIC')
 
-    data = []
     tenants = aci.Tenant.get_deep(session)
     for tenant in tenants:
         contracts_interfaces = tenant.get_children(only_class=ContractInterface)

--- a/samples/aci-show-subnets.py
+++ b/samples/aci-show-subnets.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python
+
+"""
+Simple application that logs on to the APIC and displays all
+of the Subnets.
+"""
 import acitoolkit.acitoolkit as aci
 
-
+data = []
+longest_names = {'Tenant': len('Tenant'),
+                 'Application Profile': len('Application Profile'),
+                 'Bridge Domain': len('Bridge Domain'),
+                 'Subnet': len('Subnet'),
+                 'Scope': len('Scope')}
 def main():
     """
     Main show Subnets routine
     :return: None
     """
-    # Login to APIC
+    # Take login credentials from the command line if provided
+    # Otherwise, take them from your environment variables file ~/.profile
     description = ('Simple application that logs on to the APIC'
                    ' and displays all of the Subnets.')
     creds = aci.Credentials('apic', description)
+    creds.add_argument('--tenant', help='The name of Tenant')
     args = creds.get()
+
+    # Login to APIC
     session = aci.Session(args.url, args.login, args.password)
     resp = session.login()
     if not resp.ok:
@@ -19,26 +33,49 @@ def main():
 
     # Download all of the tenants, app profiles, and Subnets
     # and store the names as tuples in a list
-    data = []
     tenants = aci.Tenant.get(session)
     for tenant in tenants:
-        apps = aci.AppProfile.get(session, tenant)
-        for app in apps:
-            bds = aci.BridgeDomain.get(session, tenant)
-            for bd in bds:
-                subnets = aci.Subnet.get(session, bd, tenant)
-                if len(subnets) == 0:
-                    data.append((tenant.name, app.name, bd.name, "", ""))
-                else:
-                    for subnet in subnets:
-                        data.append((tenant.name, app.name, bd.name, subnet.addr, subnet.get_scope()))
+        check_longest_name(tenant.name, "Tenant")
+        if args.tenant is None:
+            get_subnet(session, tenant)
+        else:
+            if tenant.name == args.tenant:
+                get_subnet(session, tenant)
 
     # Display the data downloaded
-    template = "{0:20} {1:20} {2:20} {3:18} {4:15}"
-    print(template.format("Tenant              ", "AppProfile          ", "BridgeDomain        ", "Subnet            ", "Scope          "))
-    print(template.format("--------------------", "--------------------", "--------------------", "------------------", "---------------"))
-    for rec in data:
+    template = '{0:' + str(longest_names["Tenant"]) + '} ' \
+               '{1:' + str(longest_names["Application Profile"]) + '} ' \
+               '{2:' + str(longest_names["Bridge Domain"]) + '} ' \
+               '{3:' + str(longest_names["Subnet"]) + '} ' \
+               '{4:' + str(longest_names["Scope"]) + '}'
+    print(template.format("Tenant", "Application Profile", "Bridge Domain", "Subnet", "Scope"))
+    print(template.format('-' * longest_names["Tenant"],
+                          '-' * longest_names["Application Profile"],
+                          '-' * longest_names["Bridge Domain"],
+                          '-' * longest_names["Subnet"],
+                          '-' * longest_names["Scope"]))
+    for rec in sorted(data):
         print(template.format(*rec))
+
+def get_subnet(session, tenant):
+    apps = aci.AppProfile.get(session, tenant)
+    for app in apps:
+        check_longest_name(app.name, "Application Profile")
+        bds = aci.BridgeDomain.get(session, tenant)
+        for bd in bds:
+            check_longest_name(bd.name, "Bridge Domain")
+            subnets = aci.Subnet.get(session, bd, tenant)
+            if len(subnets) == 0:
+                data.append((tenant.name, app.name, bd.name, "", ""))
+            else:
+                for subnet in subnets:
+                    check_longest_name(subnet.addr, "Subnet")
+                    check_longest_name(subnet.get_scope(), "Scope")
+                    data.append((tenant.name, app.name, bd.name, subnet.addr, subnet.get_scope()))
+
+def check_longest_name(item, title):
+    if len(item) > longest_names[title]:
+        longest_names[title] = len(item)
 
 if __name__ == '__main__':
     try:

--- a/samples/aci-show-tenant-detail.py
+++ b/samples/aci-show-tenant-detail.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import os
+import acitoolkit.acitoolkit as aci
+
+def main():
+    # Login to APIC
+    description = ('Simple application that logs on to the APIC'
+                   ' and displays all of the External Subnets.')
+    creds = aci.Credentials('apic', description)
+    creds.add_argument('--tenant', help='The name of Tenant')
+    args = creds.get()
+
+    option = ''
+    if args.tenant is not None:
+        option = ' --tenant ' + args.tenant
+
+    execute('show contexts', 'aci-show-contexts.py' + option)    
+    execute('show contracts', 'aci-show-contracts.py' + option)
+    execute('show epgs', 'aci-show-epgs.py' + option)
+    execute('show external epgs', 'aci-show-external-networks.py' + option)
+    execute('show ip interface brief', 'aci-show-ip-int-brief.py' + option)
+    execute('show subnets', 'aci-show-subnets.py' + option)
+
+def execute(title, command):
+    show_header(title)
+    os.system('./' + command)
+
+def show_header(title):
+    print("\n==================== " + title + " ====================")
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
# Changes

- Add option to speficy tenant
    - samples/aci-show-contexts.py
    - samples/aci-show-contracts.py
    - samples/aci-show-epgs.py
    - samples/aci-show-external-networks.py
    - samples/aci-show-imported-contracts.py
    - samples/aci-show-ip-int-brief.py
    - samples/aci-show-subnets.py
- I tested it in the following environment.
    - [Python 2.7.13](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-2.7.13)
    - [Python 3.5.3](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-3.5.3)
    - [Python 3.6.1](https://github.com/sig9org/acitoolkit-alpine/tree/master/versions/library-3.6.1)

# Examples

## Without tenant option

```sh
$ ./aci-show-contexts.py
Tenant         Context
-------------- ---------
common         copy
common         default
infra          overlay-1
mgmt           inb
mgmt           oob
```

## With tenant option

```sh
$ ./aci-show-contexts.py --tenant mgmt
Tenant         Context
-------------- -------
mgmt           inb
mgmt           oob
```