### PR TITLE
Fix for Python 2 DeepDiff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,6 @@ ACIToolkit Installer using setuptools
 import os, sys
 from setuptools import setup
 
-# Check if Python 2 is running.
-if sys.version_info[0] == 2:
-    deepdiff_version = "==3.3.0"
-else:
-    deepdiff_version = ""
-
 base_dir = os.path.dirname(__file__)
 
 about = {}
@@ -40,7 +34,7 @@ setup(
                       "jsonschema",
                       "graphviz",
                       "ipaddress",
-                      "deepdiff%s" % deepdiff_version],
+                      "{}".format("deepdiff==3.3.0" if sys.version_info[0] == 2 else "deepdiff")],
     tests_requires=["mock"],
     description="This library allows basic Cisco ACI APIC configuration.",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 """
 ACIToolkit Installer using setuptools
 """
-import os
+import os, sys
 from setuptools import setup
 
+# Check if Python 2 is running.
+if sys.version_info[0] == 2:
+    deepdiff_version = "==3.3.0"
+else:
+    deepdiff_version = ""
 
 base_dir = os.path.dirname(__file__)
 
@@ -35,7 +40,7 @@ setup(
                       "jsonschema",
                       "graphviz",
                       "ipaddress",
-                      "deepdiff"],
+                      "deepdiff%s" % deepdiff_version],
     tests_requires=["mock"],
     description="This library allows basic Cisco ACI APIC configuration.",
 )


### PR DESCRIPTION
Hey there,

I am trying to build the ACIToolkit in Python 2 however, an error occurs when installing DeepDiff as they dropped support for Python 2. The last version to use it was [`3.3.0`](https://github.com/seperman/deepdiff#deepdiff-v-407). 

This PR adds logic to check the version of Python running and if it's Python 2, install version 3.3.0.