### PR TITLE
Use a named logger so they can be formatted and filtered

### DIFF
--- a/acitoolkit/acibaseobject.py
+++ b/acitoolkit/acibaseobject.py
@@ -38,6 +38,9 @@ from .aciSearch import AciSearch, Searchable
 from .acisession import Session
 
 
+log = logging.getLogger(__name__)
+
+
 class BaseRelation(object):
     """
     Class for all basic relations.
@@ -132,7 +135,7 @@ class BaseACIObject(AciSearch):
         # self.unsubscribe = self._instance_unsubscribe
         # self.has_events = self._instance_has_events
         # self.get_event = self._instance_get_event
-        logging.debug('Creating %s %s', self.__class__.__name__, name)
+        log.debug('Creating %s %s', self.__class__.__name__, name)
         if self._parent is not None:
             if self._parent.has_child(self):
                 self._parent.remove_child(self)
@@ -1109,7 +1112,7 @@ class BaseACIObject(AciSearch):
             raise ValueError
         if isinstance(tenant, str):
             raise TypeError
-        logging.debug('%s.get called', toolkit_class.__name__)
+        log.debug('%s.get called', toolkit_class.__name__)
         if tenant is None:
             tenant_url = ''
         else:
@@ -1122,9 +1125,9 @@ class BaseACIObject(AciSearch):
         resp = []
         if ret.ok:
             data = ret.json()['imdata']
-            logging.debug('response returned %s', data)
+            log.debug('response returned %s', data)
         else:
-            logging.error('Could not get %s. Received response: %s', query_url, ret.text)
+            log.error('Could not get %s. Received response: %s', query_url, ret.text)
             return resp
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -1629,8 +1632,8 @@ class BaseACIPhysModule(BaseACIPhysObject):
                 self._parent = parent
                 self._parent.add_child(self)
 
-        logging.debug('Creating %s %s', self.__class__.__name__,
-                      'pod-' + self.pod + '/node-' + self.node + '/slot-' + self.slot)
+        log.debug('Creating %s %s', self.__class__.__name__,
+                  'pod-' + self.pod + '/node-' + self.node + '/slot-' + self.slot)
 
     def get_slot(self):
         """Gets slot id

--- a/acitoolkit/acifakeapic.py
+++ b/acitoolkit/acifakeapic.py
@@ -28,6 +28,9 @@ from .acisession import Session
 import logging
 
 
+log = logging.getLogger(__name__)
+
+
 class FakeResponse(object):
     """
     Create a Fake shell of a Requests.Response object
@@ -162,7 +165,7 @@ class FakeSession(Session):
             try:
                 lst = self._classes[cl]
             except KeyError:
-                logging.error('Unknown class %s', cl)
+                log.error('Unknown class %s', cl)
                 return []
             return [cl_obj for _, cl_obj in lst]
         for _, lst in self._classes.iteritems():

--- a/acitoolkit/aciphysobject.py
+++ b/acitoolkit/aciphysobject.py
@@ -45,6 +45,9 @@ from .aciTable import Table
 import acitoolkit as ACI
 
 
+log = logging.getLogger(__name__)
+
+
 class Systemcontroller(BaseACIPhysModule):
     """ class of the motherboard of the APIC controller node   """
 
@@ -1053,7 +1056,7 @@ class Pod(BaseACIPhysObject):
         self.dn = dn
         self.pod = pod
         self.name = 'pod-' + str(self.pod)
-        logging.debug('Creating %s %s', self.__class__.__name__, self.pod)
+        log.debug('Creating %s %s', self.__class__.__name__, self.pod)
         if dn is not None:
             self.atomic_counters = AtomicCountersOnGoing(self, dn)
         if parent:
@@ -1210,8 +1213,8 @@ class Node(BaseACIPhysObject):
         self.v4_proxy_ip = None
         self.mac_proxy_ip = None
         self.dynamic_load_balancing_mode = None
-        logging.debug('Creating %s %s', self.__class__.__name__, 'pod-' +
-                      str(self.pod) + '/node-' + str(self.node))
+        log.debug('Creating %s %s', self.__class__.__name__, 'pod-' +
+                  str(self.pod) + '/node-' + str(self.node))
         # self._common_init(parent)
 
     @staticmethod
@@ -2162,8 +2165,8 @@ class Link(BaseACIPhysObject):
             raise TypeError("Parent object can't be a string")
         self.type = 'link'
         self._session = None
-        logging.debug('Creating %s %s', self.__class__.__name__,
-                      'pod-%s link-%s' % (self.pod, self.link))
+        log.debug('Creating %s %s', self.__class__.__name__,
+                  'pod-%s link-%s' % (self.pod, self.link))
         # self._common_init(parent)
 
     @staticmethod

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -48,6 +48,9 @@ from .acicounters import InterfaceStats
 from .acitoolkitlib import Credentials
 
 
+log = logging.getLogger(__name__)
+
+
 class Tenant(BaseACIObject):
     """
     The Tenant class is used to represent the tenants within the acitoolkit
@@ -4189,7 +4192,7 @@ class Filter(BaseACIObject):
         # ContractSubject instead of Tenants
         contract_subject_parent = None
         if isinstance(parent, ContractSubject):
-            logging.warning('The parent of a Filter should be a Tenant Object!')
+            log.warning('The parent of a Filter should be a Tenant Object!')
             contract_subject_parent = parent
             parent = parent.get_parent().get_parent()
         super(Filter, self).__init__(filter_name, parent)
@@ -4511,7 +4514,7 @@ class FilterEntry(BaseACIObject):
 
         if isinstance(tenant, str):
             raise TypeError
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         if tenant is None:
             tenant_url = ''
         else:
@@ -4522,7 +4525,7 @@ class FilterEntry(BaseACIObject):
                      'target-subtree-class=%s' % (tenant_url, apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             dn = object_data['vzRsSubjFiltAtt']['attributes']['dn']
@@ -4542,7 +4545,7 @@ class FilterEntry(BaseACIObject):
                     filter_data = ret.json()['imdata']
                     if len(filter_data) == 0:
                         continue
-                    logging.debug('response returned %s', filter_data)
+                    log.debug('response returned %s', filter_data)
                     resp = []
                     obj = cls(entry_name, parent)
                     attribute_data = filter_data[0]['vzEntry']['attributes']
@@ -5706,7 +5709,7 @@ class IPEndpoint(BaseACIObject):
                 elif 'fvIp' in ep:
                     attr = ep['fvIp']['attributes']
                 else:
-                    logging.error('Could not get EPG endpoints from the APIC %s', ep)
+                    log.error('Could not get EPG endpoints from the APIC %s', ep)
                     break
                 ep_dn = str(attr['dn'])
                 ep_addr = str(attr['addr'])
@@ -5867,13 +5870,13 @@ class PhysDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
 
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -5919,12 +5922,12 @@ class PhysDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
             obj = toolkit_class(name, parent)
@@ -6013,12 +6016,12 @@ class VmmDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6044,12 +6047,12 @@ class VmmDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
 
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6133,12 +6136,12 @@ class L2ExtDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6164,12 +6167,12 @@ class L2ExtDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
 
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6253,12 +6256,12 @@ class L3ExtDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree'
                       '&target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6285,12 +6288,12 @@ class L3ExtDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target=subtree&'
                       'target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
 
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['name'])
@@ -6473,12 +6476,12 @@ class EPGDomain(BaseACIObject):
         toolkit_class = cls
         apic_class = cls._get_apic_classes()[0]
         parent = None
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         query_url = (('/api/mo/uni.json?query-target='
                       'subtree&target-subtree-class=') + str(apic_class))
         ret = session.get(query_url)
         data = ret.json()['imdata']
-        logging.debug('response returned %s', data)
+        log.debug('response returned %s', data)
         resp = []
         for object_data in data:
             name = str(object_data[apic_class]['attributes']['uid'])
@@ -6583,7 +6586,7 @@ class NetworkPool(BaseACIObject):
         toolkit_class = cls
         apic_classes = cls._get_apic_classes()
 
-        logging.debug('%s.get called', cls.__name__)
+        log.debug('%s.get called', cls.__name__)
         resp = []
         for ac in apic_classes:
             query_url = (('/api/mo/uni.json?query-target=subtree&'


### PR DESCRIPTION
The way it is now, all log messages go to the "root" logger. This makes it hard to customize and filter messages with a config. Giving the loggers a name allows customization.

i.e. with object config:
```yml
loggers:
  acitoolkit:
    level: INFO
  acitoolkit.acitoolkit:
    level: WARN
```