### PR TITLE
Allow FQDNs on report Application GUI

### DIFF
--- a/applications/reports/Forms.py
+++ b/applications/reports/Forms.py
@@ -77,7 +77,7 @@ class CredentialsForm(Form):
     """
     class to hold the form definition for the credentials
     """
-    ipaddr = StringField('APIC IP Address:',
+    ipaddr = StringField('APIC IP Address/FQDN:',
                          validators=[DataRequired(), CustomValidation()])
     secure = BooleanField('Use secure connection', validators=[])
     username = StringField('APIC Username:', validators=[DataRequired()])

--- a/applications/reports/Forms.py
+++ b/applications/reports/Forms.py
@@ -23,23 +23,16 @@ Forms for report GUI
 from flask_wtf import Form
 from wtforms import StringField, SubmitField, PasswordField, BooleanField
 from wtforms import TextAreaField, SelectField
-from wtforms.validators import DataRequired, IPAddress
+from wtforms.validators import DataRequired, IPAddress, ValidationError
 from wtforms.compat import string_types, text_type
 import re
 import ipaddress
 
 __author__ = 'edsall'
 
-class ValidationError(ValueError):
-    """
-    Raised when a validator fails to validate its input.
-    """
-    def __init__(self, message='', *args, **kwargs):
-        ValueError.__init__(self, message, *args, **kwargs)
-
 class CustomValidation(object):
     """
-    Helper class for checking hostnames for validation. Validates IPv4 or IPv6 addresses
+    Custom validation class for checking APIC input. Validates IPv4 or IPv6 addresses
     If not an IP, uses a regex to invalidate symbols from FQDN
     """
 

--- a/applications/reports/templates/credentials.html
+++ b/applications/reports/templates/credentials.html
@@ -4,7 +4,7 @@
 <p>Enter the Credentials used to communicate with the APIC.</p>
 <br>
 {{ wtf.quick_form(form, form_type='horizontal',
-                  horizontal_columns=('lg', 4, 2)) }}
+                  horizontal_columns=('lg', 2, 2)) }}
 {% if ipaddr %}
 <br>
 <p><u>Current Settings</u>

--- a/applications/reports/templates/credentials.html
+++ b/applications/reports/templates/credentials.html
@@ -4,12 +4,12 @@
 <p>Enter the Credentials used to communicate with the APIC.</p>
 <br>
 {{ wtf.quick_form(form, form_type='horizontal',
-                  horizontal_columns=('lg', 2, 2)) }}
+                  horizontal_columns=('lg', 4, 2)) }}
 {% if ipaddr %}
 <br>
 <p><u>Current Settings</u>
 <br>APIC Username: <b>{{ username }}</b>
-<br>APIC IP Address: <b>{{ ipaddr }}</b>
+<br>APIC IP Address/FQDN: <b>{{ ipaddr }}</b>
 <br>Secure Connection: <b>{{ security }}</b></p>
 {{ wtf.quick_form(reset_form) }}
 {% endif %}


### PR DESCRIPTION
The current "backend" code allows the use of both FQDN and IP Addressess when connecting to APIC, however, due to the IPAddress validator used in the flask form (Forms.py), non-ip addresses are marked as invalid on the GUI.

_Normally, APICs should be reachable on both FQDN or IP address so this is not a major showstopper, but i ran into this issue when trying to use the acitoolkit against the Devnet Sandbox (sandboxapicdc.cisco.com) which i guess is behind a Proxy/Load Balancer so it cannot be reached directly over IP._

The proposed merge includes:
- Change from Required to DataRequired validator (Required is an alias and might be deprecated)
- Imported ValidatorError to validate the Custom Validator
- Import of re and ipaddress modules for the Custom Validator
- Wrote a custom validator that tries to validate the input as IP address. If it fails, it checks the input for characters not permitted in FQDNs (I´m not an expert on regex so this is open to improvement)
- The CustomValidation is then used instead of the IPAddress validator
- Modified "APIC IP Address:" for "APIC IP Address/FQDN:" on GUI
