### PR TITLE
Handling the Removal of the 'ip' Key in the 'fvCEp' Object for ACI 5.1

### DIFF
--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -5385,7 +5385,13 @@ class Endpoint(BaseACIObject):
                 epg = EPG(str(ep['dn']).split('/')[3][4:], app_profile)
             endpoint = Endpoint(str(ep['name']), parent=epg)
             endpoint.mac = str(ep['mac'])
-            endpoint.ip = str(ep['ip'])
+            try:
+                endpoint.ip = str(ep['ip'])
+            except KeyError:
+                for child in children:
+                    if "fvIp" in child:
+                        endpoint.ip = str(child['fvIp']['attributes']['addr'])
+                        break
             endpoint.encap = str(ep['encap'])
             endpoint.timestamp = str(ep['modTs'])
             for child in children:


### PR DESCRIPTION
Addresses the Dec 15, 2020 remark in
https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/5x/release-notes/cisco-apic-release-notes-511.html

* In ACI 5.1 the fvCEp object no longer contains a key for IP
* The replacement code tries the original assignment and if that fails
  grabs the first fvIp object and uses that 'addr'
* Because a fvCEp object can contain multiple fvIp objects it may be
  ideal to be more selective on which IP is grabbed or a way to handle
an endpoint having multiple IPs.

Let me know if there is a better way we should think about detecting and managing version incompatibilities or if we want to address handling multiple fvIps.

WIP solution for #373 