### PR TITLE
Handling the Removal of the 'ip' Key in the 'fvCEp' Object for ACI 5.1

### DIFF
--- a/acitoolkit/__about__.py
+++ b/acitoolkit/__about__.py
@@ -19,7 +19,7 @@ __title__ = "acitoolkit"
 __summary__ = "Toolkit for Cisco ACI Fabrics"
 __uri__ = "http://datacenter.github.io/acitoolkit/"
 
-__version__ = "0.4"
+__version__ = "0.41"
 
 __author__ = "Cisco Systems, Inc."
 __email__ = "acitoolkit@external.cisco.com"

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -5395,7 +5395,7 @@ class Endpoint(BaseACIObject):
             endpoint.ip = str(ep.get('ip', ""))
             for child in children:
                 if "fvIp" in child:
-                    child_ip = str(child.get('fvIp', {}).get('attributes', {}).get('addr'))
+                    child_ip = child.get('fvIp', {}).get('attributes', {}).get('addr')
                     if child_ip:
                         endpoint.ips.append(child_ip)
             endpoint.encap = str(ep['encap'])

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -5135,7 +5135,6 @@ class Endpoint(BaseACIObject):
         super(Endpoint, self).__init__(name, parent=parent)
         self.mac = None
         self.ip = None
-        self.ips = []
         self.encap = None
         self.if_name = None
         self.if_dn = []
@@ -5393,11 +5392,6 @@ class Endpoint(BaseACIObject):
             endpoint = Endpoint(str(ep['name']), parent=epg)
             endpoint.mac = str(ep['mac'])
             endpoint.ip = str(ep.get('ip', ""))
-            for child in children:
-                if "fvIp" in child:
-                    child_ip = child.get('fvIp', {}).get('attributes', {}).get('addr')
-                    if child_ip:
-                        endpoint.ips.append(child_ip)
             endpoint.encap = str(ep['encap'])
             endpoint.timestamp = str(ep['modTs'])
             for child in children:

--- a/acitoolkit/acitoolkit.py
+++ b/acitoolkit/acitoolkit.py
@@ -5135,6 +5135,7 @@ class Endpoint(BaseACIObject):
         super(Endpoint, self).__init__(name, parent=parent)
         self.mac = None
         self.ip = None
+        self.ips = []
         self.encap = None
         self.if_name = None
         self.if_dn = []
@@ -5210,7 +5211,7 @@ class Endpoint(BaseACIObject):
             self.encap = str(attributes.get('encap'))
         if 'lcC' in attributes:
             life_cycle = str(attributes.get('lcC'))
-        if life_cycle is not '':
+        if life_cycle != '':
             self.life_cycle = life_cycle
         if 'type' in attributes:
             self.type = str(attributes.get('type'))
@@ -5391,7 +5392,12 @@ class Endpoint(BaseACIObject):
                 epg = EPG(str(ep['dn']).split('/')[3][4:], app_profile)
             endpoint = Endpoint(str(ep['name']), parent=epg)
             endpoint.mac = str(ep['mac'])
-            endpoint.ip = str(ep['ip'])
+            endpoint.ip = str(ep.get('ip', ""))
+            for child in children:
+                if "fvIp" in child:
+                    child_ip = str(child.get('fvIp', {}).get('attributes', {}).get('addr'))
+                    if child_ip:
+                        endpoint.ips.append(child_ip)
             endpoint.encap = str(ep['encap'])
             endpoint.timestamp = str(ep['modTs'])
             for child in children:


### PR DESCRIPTION
there is currently an issue open on github here
[Show endpoints sample does retrieve key error in acitoolkit.py · Issue #376 · datacenter/acitoolkit](https://github.com/datacenter/acitoolkit/issues/376) 

There was a PR that was not merged and closed closed that talks about changes made to Cisco ACI that caused this issue
[Handling the Removal of the 'ip' Key in the 'fvCEp' Object for ACI 5.1 by timway · Pull Request #374 · datacenter/acitoolkit](https://github.com/datacenter/acitoolkit/pull/374) 

tldr: 
IP key has been removed from the endpoints payload.

Addresses the Dec 15, 2020 remark in
[Cisco Application Policy Infrastructure Controller Release Notes, Release 5.1(1)](https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/5x/release-notes/cisco-apic-release-notes-511.html) 

In ACI 5.1 the fvCEp object no longer contains a key for IP

"Because a fvCEp object can contain multiple fvIp objects it may be
ideal to be more selective on which IP is grabbed or a way to handle
an endpoint having multiple IPs"


This PR aims to address this issue by checking for ip address on endpoint, and if not there, keep ip field blank. For those looking for ips associated to endpoints and their children, there is a attr on endpoint labled secondary_ip which is a list of ips
