### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+dist/
 *.pyc
 *.egg-info
 .DS_STORE


### PR DESCRIPTION
Added build and dist directories in .gitignore .
Useful when using this repo as a git local clone or git submodule.
In this way we can use git pull to update our local copies in our projects.