### PR TITLE
issues-383: https://github.com/datacenter/acitoolkit/issues/383

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ jsonschema
 graphviz
 ipaddress
 deepdiff==3.3.0
+attr
+attrs


### PR DESCRIPTION
Added attr & attrs in the rquirements.txt to handle the 'ModuleNotFoundError' error generated by 'jsonschema' module (Circular Dependancy)