### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # acitoolkit [![Documentation Status](https://readthedocs.org/projects/acitoolkit/badge/?version=latest)](https://readthedocs.org/projects/acitoolkit/?badge=latest) [![Build Status](https://api.shippable.com/projects/54ea96315ab6cc13528d52ad/badge?branchName=master)](https://app.shippable.com/projects/54ea96315ab6cc13528d52ad/builds/latest) [![](https://img.shields.io/badge/License-Apache2-blue.svg)](https://img.shields.io/badge/License-Apache2-blue.svg)
 [![Join the chat at https://gitter.im/datacenter/acitoolkit](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/datacenter/acitoolkit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+> [!CAUTION]
+> ## ⚠️ DEPRECATION NOTICE
+>
+> **This project is deprecated and no longer actively maintained.**
+>
+> ### Recommended Alternatives:
+> 1. **[Cisco ACI Cobra SDK](https://github.com/datacenter/cobra/)** - Official Python SDK with full ACI object model support
+> 2. **[Cisco ACI Ansible Collection](https://galaxy.ansible.com/cisco/aci)** - For automation workflows
+> 3. **[Cisco ACI Terraform Provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest)** - For Infrastructure as Code
+> 4. **[Network-as-Code (NAC)](https://netascode.cisco.com/)** - Declarative YAML-based configuration
+>
+> No new features will be added.
 
 # Description
 


### PR DESCRIPTION
This project is now deprecated in favor of officially supported alternatives.

The README now includes a deprecation banner directing users to:
- Cisco ACI Cobra SDK
- Cisco ACI Ansible Collection  
- Cisco ACI Terraform Provider
- Network-as-Code (NAC)

After merging, the repository will be archived.